### PR TITLE
Add CollectionGrid component

### DIFF
--- a/examples/nextjs/components/CollectionGrid/CollectionGrid.js
+++ b/examples/nextjs/components/CollectionGrid/CollectionGrid.js
@@ -1,0 +1,33 @@
+import React, {useState, useEffect} from 'react';
+import $nacelle from 'services/nacelle';
+
+import ProductGallery from 'components/ProductGallery';
+
+const CollectionGrid = ({ fields }) => {
+  const [products, setProducts] = useState([])
+  const collectionHandle = fields.collectionHandle
+
+  useEffect(() => {
+    const fetchCollection = async () => {
+      try {
+        const collection = await $nacelle.data.collection({ handle: collectionHandle })
+        const products = await $nacelle.data.products({ 
+          handles: collection
+          .productLists
+          .find(listEntry => listEntry.slug === 'default')
+          .handles
+        })
+        setProducts(products)
+      } catch {
+        console.warn(`Collection not found with handle: '${collectionHandle}'`)
+      }
+    }
+    fetchCollection()
+  }, [collectionHandle])
+
+  return (
+    <ProductGallery products={products} />
+  );
+};
+
+export default CollectionGrid;

--- a/examples/nextjs/components/CollectionGrid/CollectionGrid.js
+++ b/examples/nextjs/components/CollectionGrid/CollectionGrid.js
@@ -11,7 +11,7 @@ const CollectionGrid = ({ fields }) => {
     const fetchCollection = async () => {
       try {
         const collection = await $nacelle.data.collection({ handle: collectionHandle })
-        const products = await $nacelle.data.products({ 
+        const products = await $nacelle.data.products({
           handles: collection
           .productLists
           .find(listEntry => listEntry.slug === 'default')

--- a/examples/nextjs/components/CollectionGrid/index.js
+++ b/examples/nextjs/components/CollectionGrid/index.js
@@ -1,0 +1,3 @@
+import CollectionGrid from './CollectionGrid';
+
+export default CollectionGrid;

--- a/examples/nextjs/components/ContentSections/ContentSections.js
+++ b/examples/nextjs/components/ContentSections/ContentSections.js
@@ -2,6 +2,7 @@ import React from 'react';
 import dynamic from 'next/dynamic';
 
 import HeroBanner from 'components/HeroBanner';
+import CollectionGrid from 'components/CollectionGrid';
 
 // Avoid SSR for the Side By Side component since it relies on the size
 // of the device and client-side data to choose the proper layout
@@ -23,6 +24,10 @@ const ContentSections = ({ sections }) => {
       case 'sideBySide':
         return (
           <DynamicSideBySide fields={section.fields} key={section.sys.id} />
+        );
+      case 'collectionGrid':
+        return (
+          <CollectionGrid fields={section.fields} key={section.sys.id} />
         );
       // ...add additional cases for whichever content types are needed
       default:


### PR DESCRIPTION
### WHY are these changes introduced?

Feature for [[NC-1620](https://nacelle.atlassian.net/browse/NC-1620)]

### WHAT is this pull request doing?

This adds the CollectionGrid component which is rendered through ContentSection as case "collectionGrid".

Screenshot of the bottom of the hero banner to the CollectionGrid of 'eyewear':
<img width="1774" alt="Screen Shot 2020-09-02 at 1 35 48 PM" src="https://user-images.githubusercontent.com/8623522/92017284-8b00a380-ed21-11ea-8120-6a7f06a58227.png">


### How to Test

Currently in Prairie Wind Apparel, there is a collection content section (in contentful) on the homepage for eyewear that should display directly below the hero banner. This should be rendered.
