### PR TITLE
Fix Preview Mode Logic Gate

### DIFF
--- a/examples/nextjs/services/nacelle.js
+++ b/examples/nextjs/services/nacelle.js
@@ -32,7 +32,7 @@ const previewVariablesExist = Boolean(
 );
 
 if (
-  (process.env.NACELLE_PREVIEW_MODE || inPreviewBranch) &&
+  (process.env.NACELLE_PREVIEW_MODE === 'true' || inPreviewBranch) &&
   previewVariablesExist
 ) {
   // Initialize the Preview Connector

--- a/examples/nextjs/services/nacelle.js
+++ b/examples/nextjs/services/nacelle.js
@@ -26,15 +26,24 @@ client.data.allCollections = (params) => clientPIM.data.allCollections(params);
 const previewBranchName = 'preview';
 const vercelBranch = process.env.VERCEL_GITHUB_COMMIT_REF;
 const inPreviewBranch = vercelBranch && vercelBranch === previewBranchName;
+const previewModeToggled =
+  process.env.NACELLE_PREVIEW_MODE === 'true' || inPreviewBranch;
 const previewVariablesExist = Boolean(
   process.env.CONTENTFUL_PREVIEW_SPACE_ID &&
     process.env.CONTENTFUL_PREVIEW_API_TOKEN
 );
 
-if (
-  (process.env.NACELLE_PREVIEW_MODE === 'true' || inPreviewBranch) &&
-  previewVariablesExist
-) {
+if (previewModeToggled && !previewVariablesExist) {
+  console.warn(
+    '\nPreview Mode not activated due to missing environment variables:\n' +
+      (!process.env.CONTENTFUL_PREVIEW_SPACE_ID &&
+        '- CONTENTFUL_PREVIEW_SPACE_ID\n') +
+      (!process.env.CONTENTFUL_PREVIEW_API_TOKEN &&
+        '- CONTENTFUL_PREVIEW_API_TOKEN\n')
+  );
+}
+
+if (previewModeToggled && previewVariablesExist) {
   // Initialize the Preview Connector
   // Note: the Contentful Preview API token is not the same as your Content Delivery API token
   const contentfulPreview = new NacelleContentfulPreviewConnector({
@@ -49,7 +58,7 @@ if (
   client.data.articles = (params) => contentfulPreview.articles(params);
   client.data.blog = (params) => contentfulPreview.blog(params);
 
-  console.log('RUNNING NACELLE IN PREVIEW MODE');
+  console.log('\nRUNNING NACELLE IN PREVIEW MODE\n');
 }
 
 export default client;


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

### Type of Change

- [x] Bug fix
- [ ] Non-breaking feature
- [ ] Breaking feature
- [x] Chore (docs, refactor, etc)

### What is being changed and why?

<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, gifs, etc are appreciated
-->

This PR addresses [DRMS-724](https://nacelle.atlassian.net/browse/DRMS-724):
> Fix Nacelle Preview env var evaluation in Next.js example

In the Next.js example project, when a `NACELLE_PREVIEW_MODE` environment variable was provided as `false`, preview mode was still enabled due to failure to account for the (`String`) type of the environment variable provided to the app by `dotenv`.

With this change, the Contentful preview connector is activated only when `NACELLE_PREVIEW_MODE=true` in `.env`.

In addition, if the user has `NACELLE_PREVIEW_MODE=true` but is missing the required variables to use preview mode, a console warning is provided to tell the user which environment variables are missing.

### How to Test

<!--
  If applicable, please provide a way to test the changes in a step-by-step manner
-->

[`examples/nextjs`]

---

With the following `.env`:
```
NACELLE_SPACE_ID="rude-parrot-iBiKZQDPOa"
NACELLE_GRAPHQL_TOKEN="8638f8ca-4934-436e-80bd-851a710abc04"
NACELLE_PREVIEW_MODE=true
CONTENTFUL_PREVIEW_SPACE_ID="iojm91u4ez5c"
CONTENTFUL_PREVIEW_API_TOKEN="oiWCa-ChHYDjgNldMroWPPjvtyh6oBjX4j9Xbp9M4LI"
```
the console should print:
<img width="245" alt="Screen Shot 2020-10-29 at 11 31 06 AM" src="https://user-images.githubusercontent.com/5732000/97596805-7ff18900-19db-11eb-8a3b-f5b5d2e1c569.png">

---

With the following `.env`:
```
NACELLE_SPACE_ID="rude-parrot-iBiKZQDPOa"
NACELLE_GRAPHQL_TOKEN="8638f8ca-4934-436e-80bd-851a710abc04"
NACELLE_PREVIEW_MODE=true
```
the console should print:
<img width="475" alt="Screen Shot 2020-10-29 at 11 30 20 AM" src="https://user-images.githubusercontent.com/5732000/97596858-8da70e80-19db-11eb-9632-4d2e0958f5da.png">

---

With the following `.env`:
```
NACELLE_SPACE_ID="rude-parrot-iBiKZQDPOa"
NACELLE_GRAPHQL_TOKEN="8638f8ca-4934-436e-80bd-851a710abc04"
NACELLE_PREVIEW_MODE=false
```
the console shouldn't print any messages related to Nacelle Preview mode.
