### PR TITLE
[gatsby-source-nacelle] Add Support for Incremental Builds

### DIFF
--- a/examples/gatsby/gatsby-config.js
+++ b/examples/gatsby/gatsby-config.js
@@ -9,7 +9,8 @@ module.exports = {
         nacelleGraphqlToken: process.env.NACELLE_GRAPHQL_TOKEN,
         cmsPreviewEnabled: process.env.NACELLE_PREVIEW_MODE,
         contentfulPreviewSpaceId: process.env.CONTENTFUL_PREVIEW_SPACE_ID,
-        contentfulPreviewApiToken: process.env.CONTENTFUL_PREVIEW_API_TOKEN
+        contentfulPreviewApiToken: process.env.CONTENTFUL_PREVIEW_API_TOKEN,
+        cacheDuration: 1000 * 60 * 60 * 24 // 1 day in ms
       }
     },
     'gatsby-plugin-sharp',

--- a/packages/gatsby-source-nacelle/README.md
+++ b/packages/gatsby-source-nacelle/README.md
@@ -64,11 +64,35 @@ module.exports = {
 
 ## Additional Features
 
+### Incremental Builds
+
+`@nacelle/gatsby-source-nacelle` uses [build caching](https://www.gatsbyjs.com/docs/build-caching/) to support [incremental builds](https://www.gatsbyjs.com/blog/2020-04-22-announcing-incremental-builds/). If you'd like to force `@nacelle/gatsby-source-nacelle` to re-source product, collection, and content data from Nacelle's Hail Frequency API after a given interval, you can do so by providing a `cacheDuration` value (in milliseconds).
+
+For example, a build with the following configuration will force a re-fetch of product, collection, and content data after 24 hours, even if that data hasn't changed:
+
+```js
+// gatsby-config.js
+require('dotenv').config();
+
+module.exports = {
+  plugins: [
+    {
+      resolve: '@nacelle/gatsby-source-nacelle',
+      options: {
+        nacelleSpaceId: process.env.NACELLE_SPACE_ID,
+        nacelleGraphqlToken: process.env.NACELLE_GRAPHQL_TOKEN,
+        cacheDuration: 1000 * 60 * 60 * 24 // 1 day in ms
+      }
+    }
+  ]
+};
+```
+
 ### Gatsby Image
 
 `@nacelle/gatsby-source-nacelle` provides a way to easily integrate with Gatsby's powerful [image processing tools](https://www.gatsbyjs.org/docs/working-with-images/#optimizing-images-with-gatsby-image) to enable progressive image loading with visually-compelling loading strategies such as [Traced SVG](https://using-gatsby-image.gatsbyjs.org/traced-svg/) and [Background Color](https://using-gatsby-image.gatsbyjs.org/background-color/). Gatsby Image is directly compatible with the `featuredMedia` of content, collections, and products, as well as the `media` of products.
 
-Enabling these image processing techniques requires installing [gatsby-source-filesystem](https://www.npmjs.com/package/gatsby-source-filesystem), [`gatsby-plugin sharp`](https://www.npmjs.com/package/gatsby-plugin-sharp), and [`gatsby-transformer-sharp`](https://www.npmjs.com/package/gatsby-transformer-sharp):
+Enabling these image processing techniques requires installing [gatsby-source-filesystem](https://www.npmjs.com/package/gatsby-source-filesystem), [`gatsby-plugin-sharp`](https://www.npmjs.com/package/gatsby-plugin-sharp), and [`gatsby-transformer-sharp`](https://www.npmjs.com/package/gatsby-transformer-sharp):
 
 ```
 npm i gatsby-source-filesystem gatsby-plugin-sharp gatsby-transformer-sharp

--- a/packages/gatsby-source-nacelle/gatsby-node.js
+++ b/packages/gatsby-source-nacelle/gatsby-node.js
@@ -11,18 +11,21 @@ exports.pluginOptionsSchema = ({ Joi }) => {
   return Joi.object({
     nacelleSpaceId: Joi.string()
       .required()
-      .description(`Space ID from the Nacelle Dashboard`),
+      .description('Space ID from the Nacelle Dashboard'),
     nacelleGraphqlToken: Joi.string()
       .required()
-      .description(`GraphQL Token from the Nacelle Dashboard`),
+      .description('GraphQL Token from the Nacelle Dashboard'),
     contentfulPreviewSpaceId: Joi.string().description(
-      `Space ID from Contentful Dashboard settings`
+      'Space ID from Contentful Dashboard settings'
     ),
     contentfulPreviewApiToken: Joi.string().description(
-      `Contentful Preview API token from Contentful Dashboard settings`
+      'Contentful Preview API token from Contentful Dashboard settings'
     ),
     cmsPreviewEnabled: Joi.boolean().description(
       `Toggle Contentful Preview on and off (IMPORTANT: requires that both 'contentfulPreviewSpaceId' and 'contentfulPreviewApiToken' are also set)`
+    ),
+    cacheDuration: Joi.number().description(
+      'Max duration in ms that gatsby-source-nacelle caches product, collection, and content data from previous builds'
     )
   });
 };
@@ -85,4 +88,8 @@ exports.onCreateNode = async ({ actions, getCache, createNodeId, node }) => {
       });
     }
   }
+};
+
+exports.onPostBootstrap = async function ({ cache }) {
+  cache.set('nacelle-timestamp', Date.now());
 };

--- a/packages/gatsby-source-nacelle/src/source-nodes/collections.js
+++ b/packages/gatsby-source-nacelle/src/source-nodes/collections.js
@@ -1,9 +1,13 @@
 const { nacelleClient } = require('../services');
-const { replaceKey } = require('../utils');
+const {
+  replaceKey,
+  cacheIsInvalid,
+  hasBeenIndexedSinceLastBuild
+} = require('../utils');
 
 module.exports = async function (gatsbyApi, pluginOptions) {
-  const { actions, createNodeId, createContentDigest } = gatsbyApi;
-  const { createNode } = actions;
+  const { actions, createContentDigest, cache } = gatsbyApi;
+  const { createNode, touchNode } = actions;
 
   const { nacelleSpaceId, nacelleGraphqlToken } = pluginOptions;
 
@@ -21,21 +25,46 @@ module.exports = async function (gatsbyApi, pluginOptions) {
       replaceKey(entry, 'id', 'remoteId')
     );
 
+    // handle incremental builds
+    const lastFetched = await cache.get('nacelle-timestamp');
+
+    let newNodeCount = 0;
+
     formattedData.forEach((entry) => {
-      const nodeMeta = {
-        id: createNodeId(
-          `NacelleCollection-${entry.pimSyncSourceCollectionId}`
-        ),
-        parent: null,
-        children: [],
-        internal: {
-          type: 'NacelleCollection',
-          contentDigest: createContentDigest(entry)
-        }
-      };
-      const node = Object.assign({}, entry, nodeMeta);
-      createNode(node);
+      if (
+        hasBeenIndexedSinceLastBuild(entry, lastFetched) ||
+        cacheIsInvalid(lastFetched, pluginOptions)
+      ) {
+        const nodeMeta = {
+          id: `NacelleCollection-${entry.pimSyncSourceCollectionId}`,
+          parent: null,
+          children: [],
+          internal: {
+            type: 'NacelleCollection',
+            contentDigest: createContentDigest(entry)
+          }
+        };
+
+        const node = Object.assign({}, entry, nodeMeta);
+        createNode(node);
+
+        newNodeCount += 1;
+      } else {
+        touchNode({
+          nodeId: `NacelleCollection-${entry.pimSyncSourceCollectionId}`
+        });
+      }
     });
+
+    if (newNodeCount) {
+      console.info(
+        `[gatsby-source-nacelle] created ${newNodeCount} new collection nodes`
+      );
+    } else {
+      console.info(
+        '[gatsby-source-nacelle] using cached collection nodes from previous build'
+      );
+    }
   } catch (err) {
     throw new Error(
       `Problem sourcing Nacelle collection nodes: ${err.message}`

--- a/packages/gatsby-source-nacelle/src/source-nodes/content.js
+++ b/packages/gatsby-source-nacelle/src/source-nodes/content.js
@@ -1,9 +1,14 @@
 const { nacelleClient } = require('../services');
-const { cmsPreviewEnabled, replaceKey } = require('../utils');
+const {
+  cmsPreviewEnabled,
+  replaceKey,
+  cacheIsInvalid,
+  hasBeenIndexedSinceLastBuild
+} = require('../utils');
 
 module.exports = async function (gatsbyApi, pluginOptions) {
-  const { actions, createNodeId, createContentDigest } = gatsbyApi;
-  const { createNode } = actions;
+  const { actions, createContentDigest, cache } = gatsbyApi;
+  const { createNode, touchNode } = actions;
 
   const {
     nacelleSpaceId,
@@ -32,19 +37,46 @@ module.exports = async function (gatsbyApi, pluginOptions) {
         .replaceKey(entry, 'fields', 'remoteFields');
     });
 
+    // handle incremental builds
+    const lastFetched = await cache.get('nacelle-timestamp');
+
+    let newNodeCount = 0;
+
     formattedData.forEach((entry) => {
-      const nodeMeta = {
-        id: createNodeId(`NacelleContent-${entry.cmsSyncSourceContentId}`),
-        parent: null,
-        children: [],
-        internal: {
-          type: 'NacelleContent',
-          contentDigest: createContentDigest(entry)
-        }
-      };
-      const node = Object.assign({}, entry, nodeMeta);
-      createNode(node);
+      if (
+        hasBeenIndexedSinceLastBuild(entry, lastFetched) ||
+        cacheIsInvalid(lastFetched, pluginOptions)
+      ) {
+        const nodeMeta = {
+          id: `NacelleContent-${entry.cmsSyncSourceContentId}`,
+          parent: null,
+          children: [],
+          internal: {
+            type: 'NacelleContent',
+            contentDigest: createContentDigest(entry)
+          }
+        };
+
+        const node = Object.assign({}, entry, nodeMeta);
+        createNode(node);
+
+        newNodeCount += 1;
+      } else {
+        touchNode({
+          nodeId: `NacelleContent-${entry.cmsSyncSourceContentId}`
+        });
+      }
     });
+
+    if (newNodeCount) {
+      console.info(
+        `[gatsby-source-nacelle] created ${newNodeCount} new content nodes`
+      );
+    } else {
+      console.info(
+        '[gatsby-source-nacelle] using cached content nodes from previous build'
+      );
+    }
   } catch (err) {
     throw new Error(`Problem sourcing Nacelle content nodes: ${err.message}`);
   }

--- a/packages/gatsby-source-nacelle/src/utils/cacheIsInvalid.js
+++ b/packages/gatsby-source-nacelle/src/utils/cacheIsInvalid.js
@@ -1,0 +1,6 @@
+module.exports = function (timestamp, pluginOptions) {
+  return (
+    Date.now() - timestamp >
+    (pluginOptions.cacheDuration || 24 * 60 * 60 * 1000)
+  );
+};

--- a/packages/gatsby-source-nacelle/src/utils/checkIndexTimestamp.js
+++ b/packages/gatsby-source-nacelle/src/utils/checkIndexTimestamp.js
@@ -1,0 +1,7 @@
+module.exports = function (itemInIndex, lastFetched) {
+  return (
+    lastFetched === undefined ||
+    (lastFetched !== undefined &&
+      itemInIndex.indexedAt * 1000 - lastFetched > 0)
+  );
+};

--- a/packages/gatsby-source-nacelle/src/utils/index.js
+++ b/packages/gatsby-source-nacelle/src/utils/index.js
@@ -1,3 +1,5 @@
+exports.cacheIsInvalid = require('./cacheIsInvalid');
 exports.cmsPreviewEnabled = require('./cmsPreviewEnabled');
 exports.createRemoteImageFileNode = require('./createRemoteImageFileNode');
+exports.hasBeenIndexedSinceLastBuild = require('./checkIndexTimestamp');
 exports.replaceKey = require('./replaceKey');


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

[DRMS-823](https://nacelle.atlassian.net/browse/DRMS-823)

> Add support for incremental builds

### Type of Change

- [x] Non-breaking feature

### What is being changed and why?

<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, gifs, etc are appreciated
-->

- Adds support for incremental builds
  - Leverages the `indexedAt` property of products, collections, and content to only update nodes which have been re-indexed since the last build
  - Provides a `cacheDuration` configuration parameter to allow cache busting after a prescribed interval
- Adds documentation for incremental build support

### How to Test

<!--
  If applicable, please provide a way to test the changes in a step-by-step manner
-->

Due to a quirk with `npm link` (used by this Lerna monorepo), please use `yarn link` instead of `npm run bootstrap`.

#### Steps

1. From the project root, `cd packages/gatsby-source-nacelle && yarn && yarn link`
2. `cd ../../examples/gatsby && rm -rf node_modules && yarn && yarn link @nacelle/gatsby-source-nacelle`
3. `yarn dev`
