### PR TITLE
Use Correct Dependency Type for Gatsby-Source-Filesystem

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "lerna run build",
     "test:ci": "jest --clearCache && lerna run test:ci",
     "lint": "lerna run lint",
+    "clean": "lerna clean",
     "bootstrap": "lerna bootstrap --hoist --nohoist=@nacelle/client-js*",
     "publish": "npm run build && lerna publish",
     "create": "node ./scripts/create"

--- a/packages/gatsby-source-nacelle/package.json
+++ b/packages/gatsby-source-nacelle/package.json
@@ -28,14 +28,12 @@
   },
   "peerDependencies": {
     "gatsby": "^2.0.32",
-    "graphql": "^14.7.0"
+    "graphql": "^14.7.0",
+    "gatsby-source-filesystem": "^2.6.1"
   },
   "devDependencies": {
     "eslint": "^7.6.0",
     "lint-staged": "^10.2.11"
-  },
-  "optionalDependencies": {
-    "gatsby-source-filesystem": "^2.6.1"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-source-nacelle/src/utils/createRemoteImageFileNode.js
+++ b/packages/gatsby-source-nacelle/src/utils/createRemoteImageFileNode.js
@@ -104,15 +104,19 @@ module.exports = async function (
     const nodeMediaArray = Array.isArray(nodeMedia) ? nodeMedia : [nodeMedia];
     const options = { isImage, imageProperties };
 
-    nodeMediaArray.forEach(async (media) => {
-      if (Array.isArray(node[media])) {
-        node.media.forEach(async (_media, idx) => {
-          await createFileNode(node, [media, idx], gatsbyApi, options);
-        });
-      } else {
-        await createFileNode(node, media, gatsbyApi, options);
-      }
-    });
+    await Promise.all(
+      nodeMediaArray.map((media) => {
+        if (Array.isArray(node[media])) {
+          return Promise.all(
+            node.media.map((_media, idx) =>
+              createFileNode(node, [media, idx], gatsbyApi, options)
+            )
+          );
+        } else {
+          return createFileNode(node, media, gatsbyApi, options);
+        }
+      })
+    );
   } catch (err) {
     throw new Error(
       `Problem creating file node for remote image: ${err.message}`

--- a/packages/gatsby-source-nacelle/src/utils/createRemoteImageFileNode.js
+++ b/packages/gatsby-source-nacelle/src/utils/createRemoteImageFileNode.js
@@ -99,31 +99,23 @@ module.exports = async function (
   gatsbyApi,
   { isImage, imageProperties } = {}
 ) {
+  // create a FileNode in Gatsby that gatsby-transformer-sharp will create optimized images for
   try {
-    // ensure that `gatsby-source-filesystem` is installed
-    require('gatsby-source-filesystem').createRemoteFileNode;
+    const nodeMediaArray = Array.isArray(nodeMedia) ? nodeMedia : [nodeMedia];
+    const options = { isImage, imageProperties };
 
-    // create a FileNode in Gatsby that gatsby-transformer-sharp will create optimized images for
-    try {
-      const nodeMediaArray = Array.isArray(nodeMedia) ? nodeMedia : [nodeMedia];
-      const options = { isImage, imageProperties };
-
-      nodeMediaArray.forEach(async (media) => {
-        if (Array.isArray(node[media])) {
-          node.media.forEach(async (_media, idx) => {
-            await createFileNode(node, [media, idx], gatsbyApi, options);
-          });
-        } else {
-          await createFileNode(node, media, gatsbyApi, options);
-        }
-      });
-    } catch (err) {
-      throw new Error(
-        `Problem creating file node for remote image: ${err.message}`
-      );
-    }
+    nodeMediaArray.forEach(async (media) => {
+      if (Array.isArray(node[media])) {
+        node.media.forEach(async (_media, idx) => {
+          await createFileNode(node, [media, idx], gatsbyApi, options);
+        });
+      } else {
+        await createFileNode(node, media, gatsbyApi, options);
+      }
+    });
   } catch (err) {
-    // if the user hasn't opted in to using Gatsby image by installing `gatsby-source-filesystem`, exit
-    return null;
+    throw new Error(
+      `Problem creating file node for remote image: ${err.message}`
+    );
   }
 };


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

**Story:** [ENG-233](https://nacelle.atlassian.net/browse/ENG-233) <!-- link to Jira story -->

> [gatsby-source-nacelle] don't include gatsby-source-filesystem by default

### Type of Change

- [ ] Bug fix
- [ ] Non-breaking feature
- [ ] Breaking feature
- [x] Chore (docs, refactor, etc)

### What is being changed and why?

<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, gifs, etc are appreciated
-->

We want devs using `gatsby-source-nacelle` to be able to opt in to using Gatsby Image. Currently, devs installing `gatsby-source-nacelle` will unwittingly be opting in to using Gatsby Image unless they install via `@nacelle/gatsby-source-nacelle` with the [`--no-optional`](https://docs.npmjs.com/cli/v6/commands/npm-install) flag.

This PR removes `gatsby-source-filesystem` from the [`optionalDependencies`](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#optionaldependencies) and adds it to the [`peerDependencies`](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#peerdependencies). This way, `gatsby-source-filesystem` is not installed via `npm i @nacelle/gatsby-source-nacelle` and requires explicit installation as described in `packages/gatsby-source-nacelle/README.md`.

#### BONUS

Slight refactor of `packages/gatsby-source-nacelle/src/utils/createRemoteImageFileNode.js` which accomplishes the following:

- Avoids nested `try { ... } catch(err) { ... }`
- Shifts the responsibility to check for the presence of `gatsby-source-filesytem` to a single file (`packages/gatsby-source-nacelle/gatsby-node.js`) rather than multiple files
- Improves image download performance by parallelizing `createRemoteFileNode` calls in a `Promise.all()`

### How to Test

<!--
  If applicable, please provide a way to test the changes in a step-by-step manner
-->

Unfortunately, running `npm run bootstrap` from the monorepo root will still install `gatsby-source-filesystem` to `examples/gatsby` as per the published `@nacelle/gatsby-source-nacelle@2.9.0`'s `optionalDependencies` array. The local `packages/gatsby-source-nacelle/package.json` doesn't seem to be respected, and I'm not sure why.

In other words, I think this will work as expected once published, but I'm having difficulty getting it to work locally due to Lerna quirks.
