### PR TITLE
Fix typo in the expose-metafields script

### DIFF
--- a/packages/react-recharge/scripts/expose-metafields.js
+++ b/packages/react-recharge/scripts/expose-metafields.js
@@ -57,7 +57,7 @@ async function addMetaFields() {
 
 function validateMetafields(requiredFields, exposedMetafields) {
   const subscriptions = exposedMetafields.filter(
-    ({ node }) => node.namespace === 'subscription'
+    ({ node }) => node.namespace === 'subscriptions'
   );
 
   const matchedFields = subscriptions


### PR DESCRIPTION
Fix typo in the expose-metafields script (#27)


### Type of Change

- [x] Bug fix
- [x] Non-breaking feature
- [ ] Breaking feature
- [ ] Chore (docs, refactor, etc)

### What is being changed and why?
- It only adds an `s` to the `validateMetafields` method.
- Without that extra `s` the `npx expose-metafield` will crash because the code is looking for a namespace on the metafields called `subscriptions`.
<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, gifs, etc are appreciated
-->