### PR TITLE
[nextjs] Configure API Routes for Previewing Products, Collections, and Content

### DIFF
--- a/examples/nextjs/.env.example
+++ b/examples/nextjs/.env.example
@@ -1,0 +1,11 @@
+NACELLE_SPACE_ID=<your-nacelle-space-id>
+NACELLE_GRAPHQL_TOKEN=<your-nacelle-space-token>
+PIM_LOCALE=<your-pim-locale> # e.g. 'en-us'
+CMS_LOCALE=<your-cms-locale> # e.g. 'en-US'
+
+## variables needed for PIM & CMS preview mode:
+NACELLE_PREVIEW_MODE=false # set to true to enable
+MYSHOPIFY_DOMAIN=<your-myshopify-domain>
+SHOPIFY_STOREFRONT_ACCESS_TOKEN=<your-shopify-storefront-access-token>
+CONTENTFUL_SPACE_ID=<your-contentful-space-id>
+CONTENTFUL_PREVIEW_API_TOKEN=<your-contentful-preview-api-token>

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -25,6 +25,16 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 This project uses [Next.js Preview](https://nextjs.org/docs/advanced-features/preview-mode) conventions to fetch unpublished products from Shopify and content from Contentful. In order to activate preview, you must access the app via the [API Route](https://nextjs.org/docs/api-routes/introduction) `/api/preview`, which takes a `path` query parameter. For example, to preview an unpublished Shopify product with the handle `dania-glasses`, visit `/api/preview?path=/products/dania-glasses`. To preview an unpublished page with the handle `shipping-policy`, visit `/api/preview?path=/pages/shipping-policy`. In both cases, `/pages/api/preview.js` will redirect you to the desired path, and will pass `context.preview` to `getStaticProps` (docs)[https://nextjs.org/docs/advanced-features/preview-mode#fetch-preview-data] to signal to the `$nacelle` client that it should fetch preview data.
 
+### Configuring Preivew Routes in Contentful
+
+If you have a preview configuration in Contentful (settings -> content preview) to make it easy for content editors to preview draft pages (recommended), be sure to configure preview routes with the `/api/preview?path=/some/path` convention described above.
+
+For instance, the `Page` type can be previewed with:
+
+```
+https://my-nacelle-preview-site.vercel.app/api/preview?path=/pages/{entry_field.handle}
+```
+
 ## Exit Preview Mode
 
 To [delete the Next.js Preview cookies](https://nextjs.org/docs/advanced-features/preview-mode#clear-the-preview-mode-cookies), simply visit `/api/exit-preview`.

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -5,7 +5,7 @@ First, setup the appropriate environment variables in `.env.local`:
 - `NACELLE_SPACE_ID` - your Nacelle Space Id from the Nacelle dashboard
 - `NACELLE_GRAPHQL_TOKEN` - your Nacelle GraphQL Token from the Nacelle dashboard
 
-To use preview products & collections from Shopify and draft content from Contentful, you'll need the following environment variables in addition to the two above:
+To preview products & collections from Shopify ([docs](https://docs.getnacelle.com/integrations/shopify-preview.html)) and draft content from Contentful, you'll need the following environment variables in addition to the two above:
 
 - `NACELLE_PREVIEW_MODE` - a boolean indicating if preview mode should be enabled. `true` will enable preview mode.
 - `CONTENTFUL_SPACE_ID` - the Contentful Space Id from Contentful's settings page
@@ -13,13 +13,21 @@ To use preview products & collections from Shopify and draft content from Conten
 - `MYSHOPIFY_DOMAIN` - your \*.myshopify.com subdomain
 - `SHOPIFY_STOREFRONT_ACCESS_TOKEN` - the Storefront Access Token from your [Nacelle private app](https://docs.getnacelle.com/quick-start.html#_1-setup-shopify)
 
-Then run the app:
+Then start the app:
 
 ```bash
 npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+## Previewing Products and Content
+
+This project uses [Next.js Preview](https://nextjs.org/docs/advanced-features/preview-mode) conventions to fetch unpublished products from Shopify and content from Contentful. In order to activate preview, you must access the app via the [API Route](https://nextjs.org/docs/api-routes/introduction) `/api/preview`, which takes a `path` query parameter. For example, to preview an unpublished Shopify product with the handle `dania-glasses`, visit `/api/preview?path=/products/dania-glasses`. To preview an unpublished page with the handle `shipping-policy`, visit `/api/preview?path=/pages/shipping-policy`. In both cases, `/pages/api/preview.js` will redirect you to the desired path, and will pass `context.preview` to `getStaticProps` (docs)[https://nextjs.org/docs/advanced-features/preview-mode#fetch-preview-data] to signal to the `$nacelle` client that it should fetch preview data.
+
+## Exit Preview Mode
+
+To [delete the Next.js Preview cookies](https://nextjs.org/docs/advanced-features/preview-mode#clear-the-preview-mode-cookies), simply visit `/api/exit-preview`.
 
 ## Learn More
 
@@ -30,8 +38,8 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
 
-## Deploy on Vercel
+## Deploy with Vercel
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/import?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+The easiest way to deploy your Next.js app is with [Vercel](https://vercel.com/import).
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -23,9 +23,11 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 ## Previewing Products and Content
 
+NOTE: The preview feature takes advantage of Next.js API Routes. When running this project locally, please use the [Vercel CLI](https://vercel.com/docs/cli).
+
 This project uses [Next.js Preview](https://nextjs.org/docs/advanced-features/preview-mode) conventions to fetch unpublished products from Shopify and content from Contentful. In order to activate preview, you must access the app via the [API Route](https://nextjs.org/docs/api-routes/introduction) `/api/preview`, which takes a `path` query parameter. For example, to preview an unpublished Shopify product with the handle `dania-glasses`, visit `/api/preview?path=/products/dania-glasses`. To preview an unpublished page with the handle `shipping-policy`, visit `/api/preview?path=/pages/shipping-policy`. In both cases, `/pages/api/preview.js` will redirect you to the desired path, and will pass `context.preview` to `getStaticProps` (docs)[https://nextjs.org/docs/advanced-features/preview-mode#fetch-preview-data] to signal to the `$nacelle` client that it should fetch preview data.
 
-### Configuring Preivew Routes in Contentful
+### Configuring Preview Routes in Contentful
 
 If you have a preview configuration in Contentful (settings -> content preview) to make it easy for content editors to preview draft pages (recommended), be sure to configure preview routes with the `/api/preview?path=/some/path` convention described above.
 

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -5,12 +5,13 @@ First, setup the appropriate environment variables in `.env.local`:
 - `NACELLE_SPACE_ID` - your Nacelle Space Id from the Nacelle dashboard
 - `NACELLE_GRAPHQL_TOKEN` - your Nacelle GraphQL Token from the Nacelle dashboard
 
-To use Contentful's Preview Mode, you'll need the following environment variables in addition to the two above:
+To use preview products & collections from Shopify and draft content from Contentful, you'll need the following environment variables in addition to the two above:
 
 - `NACELLE_PREVIEW_MODE` - a boolean indicating if preview mode should be enabled. `true` will enable preview mode.
-- `VERCEL_GITHUB_COMMIT_REF` - a Vercel [system environment variable](https://vercel.com/docs/build-step#system-environment-variables) that specifies the branch the deployment was made from. Note that this is only relevant for a Vercel deployment and is set automatically by Vercel.
-- `CONTENTFUL_PREVIEW_SPACE_ID` - the Contentful Space Id from Contentful's settings page
+- `CONTENTFUL_SPACE_ID` - the Contentful Space Id from Contentful's settings page
 - `CONTENTFUL_PREVIEW_API_TOKEN` - the Contentful API Token from Contentful's settings page
+- `MYSHOPIFY_DOMAIN` - your \*.myshopify.com subdomain
+- `SHOPIFY_STOREFRONT_ACCESS_TOKEN` - the Storefront Access Token from your [Nacelle private app](https://docs.getnacelle.com/quick-start.html#_1-setup-shopify)
 
 Then run the app:
 

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -14,6 +14,7 @@
     "@nacelle/contentful-preview-connector": "^0.1.5",
     "@nacelle/react-components": "^2.10.1",
     "@nacelle/react-hooks": "^2.10.1",
+    "@nacelle/shopify-connector": "0.0.7",
     "@react-hook/media-query": "^1.1.1",
     "fuse.js": "^6.4.1",
     "next": "^10.0.4",

--- a/examples/nextjs/pages/api/exit-preview.js
+++ b/examples/nextjs/pages/api/exit-preview.js
@@ -1,0 +1,5 @@
+export default function handler(_req, res) {
+  // Clears the preview mode cookies.
+  console.info('[nacelle] exiting preview mode');
+  res.clearPreviewData();
+}

--- a/examples/nextjs/pages/api/exit-preview.js
+++ b/examples/nextjs/pages/api/exit-preview.js
@@ -2,4 +2,5 @@ export default function handler(_req, res) {
   // Clears the preview mode cookies.
   console.info('[nacelle] exiting preview mode');
   res.clearPreviewData();
+  res.redirect('/');
 }

--- a/examples/nextjs/pages/api/preview.js
+++ b/examples/nextjs/pages/api/preview.js
@@ -10,7 +10,6 @@ export default function handler(req, res) {
         'For example: https://my-preview-site/api/preview?path=/page/some-page'
     });
   }
-  console.log(`PATH: ${req.query.path}`);
 
   // Enable Preview Mode by setting the cookies
   res.setPreviewData({});
@@ -18,5 +17,9 @@ export default function handler(req, res) {
 
   // Redirect to the path from the fetched post
   // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities
+  if (req.query.path.endsWith('/homepage')) {
+    res.redirect('/');
+  }
+
   res.redirect(req.query.path);
 }

--- a/examples/nextjs/pages/api/preview.js
+++ b/examples/nextjs/pages/api/preview.js
@@ -1,0 +1,22 @@
+// If this is located at pages/api/cms-preview.js,
+// then open /api/cms-preview from your browser.
+export default function handler(req, res) {
+  // Check the secret and next parameters
+  // This secret should only be known to this API route and the CMS
+  if (!req.query.path) {
+    return res.status(400).json({
+      message:
+        'The path must be provided in a query param. ' +
+        'For example: https://my-preview-site/api/preview?path=/page/some-page'
+    });
+  }
+  console.log(`PATH: ${req.query.path}`);
+
+  // Enable Preview Mode by setting the cookies
+  res.setPreviewData({});
+  console.info('[nacelle] preview mode enabled');
+
+  // Redirect to the path from the fetched post
+  // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities
+  res.redirect(req.query.path);
+}

--- a/examples/nextjs/pages/api/preview.js
+++ b/examples/nextjs/pages/api/preview.js
@@ -1,5 +1,5 @@
-// If this is located at pages/api/cms-preview.js,
-// then open /api/cms-preview from your browser.
+// To view unpublished products, collections, or content, provide the
+// desired destination via the `path` param: `/api/preview?path=/pages/first-draft`
 export default function handler(req, res) {
   // Check the secret and next parameters
   // This secret should only be known to this API route and the CMS

--- a/examples/nextjs/pages/collections/[handle].js
+++ b/examples/nextjs/pages/collections/[handle].js
@@ -39,11 +39,13 @@ export async function getStaticPaths() {
   }
 }
 
-export async function getStaticProps({ params: { handle } }) {
-  const collection = await $nacelle.data.collection({ handle }).catch(() => {
-    console.warn(`no collection with handle '${handle}' found.`);
-    return null;
-  });
+export async function getStaticProps({ params: { handle }, preview }) {
+  const collection = await $nacelle.data
+    .collection({ handle, preview })
+    .catch(() => {
+      console.warn(`no collection with handle '${handle}' found.`);
+      return null;
+    });
 
   const defaultProductList =
     collection &&
@@ -53,12 +55,14 @@ export async function getStaticProps({ params: { handle } }) {
 
   const handles = defaultProductList?.handles;
 
-  const products = await $nacelle.data.products({ handles }).catch(() => {
-    console.warn(`no products found for collection '${handle}'.`);
-    return [];
-  });
+  const products = await $nacelle.data
+    .products({ handles, preview })
+    .catch(() => {
+      console.warn(`no products found for collection '${handle}'.`);
+      return [];
+    });
 
-  const page = await $nacelle.data.page({ handle }).catch(() => {
+  const page = await $nacelle.data.page({ handle, preview }).catch(() => {
     console.warn(`no page with handle '${handle}' found.`);
     return null;
   });

--- a/examples/nextjs/pages/index.js
+++ b/examples/nextjs/pages/index.js
@@ -11,14 +11,15 @@ export default function Home({ page }) {
   );
 }
 
-export async function getStaticProps() {
-  try {
-    const page = await $nacelle.data.page({ handle: 'homepage' });
+export async function getStaticProps({ preview }) {
+  const page = await $nacelle.data
+    .page({ handle: 'homepage', preview })
+    .catch(() => {
+      console.warn(`no page with handle 'homepage' found.`);
+      return null;
+    });
 
-    return {
-      props: { page }
-    };
-  } catch (err) {
-    console.error(`Error fetching data on homepage:\n${err}`);
-  }
+  return {
+    props: { page }
+  };
 }

--- a/examples/nextjs/pages/pages/[handle].js
+++ b/examples/nextjs/pages/pages/[handle].js
@@ -32,8 +32,8 @@ export async function getStaticPaths() {
   }
 }
 
-export async function getStaticProps({ params: { handle } }) {
-  const page = await $nacelle.data.page({ handle }).catch(() => {
+export async function getStaticProps({ params: { handle }, preview }) {
+  const page = await $nacelle.data.page({ handle, preview }).catch(() => {
     console.warn(`no page with handle '${handle}' found.`);
     return null;
   });

--- a/examples/nextjs/pages/products/[handle].js
+++ b/examples/nextjs/pages/products/[handle].js
@@ -15,7 +15,7 @@ const ProductDetail = ({ product }) => {
     return <div>Loading...</div>;
   }
 
-  return (
+  return product ? (
     <div css={styles.layout}>
       <ProductCard
         product={product}
@@ -54,6 +54,10 @@ const ProductDetail = ({ product }) => {
         </section>
       </ProductCard>
     </div>
+  ) : (
+    <>
+      <p>No product found...</p>
+    </>
   );
 };
 
@@ -69,12 +73,12 @@ export async function getStaticPaths() {
       fallback: true
     };
   } catch (err) {
-    throw new Error(`could not fetch products on homepage:\n${err}`);
+    throw new Error(`could not fetch products on product detail page:\n${err}`);
   }
 }
 
-export async function getStaticProps({ params: { handle } }) {
-  const product = await $nacelle.data.product({ handle }).catch(() => {
+export async function getStaticProps({ params: { handle }, preview }) {
+  const product = await $nacelle.data.product({ handle, preview }).catch(() => {
     console.warn(`no product with handle '${handle}' found.`);
     return null;
   });

--- a/examples/nextjs/pages/shop.js
+++ b/examples/nextjs/pages/shop.js
@@ -13,10 +13,10 @@ export default function Shop({ page, products }) {
   );
 }
 
-export async function getStaticProps() {
+export async function getStaticProps({ preview }) {
   try {
     const products = await $nacelle.data.allProducts();
-    const page = await $nacelle.data.page({ handle: 'shop' });
+    const page = await $nacelle.data.page({ handle: 'shop', preview });
     return {
       props: { products, page }
     };

--- a/examples/nextjs/services/nacelle.js
+++ b/examples/nextjs/services/nacelle.js
@@ -1,19 +1,29 @@
 import NacelleClient from '@nacelle/client-js-sdk';
 import NacelleContentfulPreviewConnector from '@nacelle/contentful-preview-connector';
+import NacelleShopifyPreviewConnector from '@nacelle/shopify-connector';
+
+function warnMissingEnvVars(envVars) {
+  console.warn(
+    '\nPreview Mode not activated due to missing environment variables:\n' +
+      envVars
+        .map((envVar) => (!process.env[envVar] ? `- ${envVar}\n` : ''))
+        .join('')
+  );
+}
 
 const settings = {
   id: process.env.NACELLE_SPACE_ID,
   token: process.env.NACELLE_GRAPHQL_TOKEN,
-  nacelleEndpoint: 'https://hailfrequency.com/v2/graphql',
+  nacelleEndpoint: 'https://hailfrequency.com/v3/graphql',
   useStatic: false
 };
 
-const shopifySettings = { ...settings, locale: 'en-us' };
-const contentfulSettings = { ...settings, locale: 'en-US' };
+const shopifySettings = { ...settings, locale: process.env.PIM_LOCALE };
+const contentfulSettings = { ...settings, locale: process.env.CMS_LOCALE };
 
 const clientPIM = new NacelleClient(shopifySettings);
 const clientCMS = new NacelleClient(contentfulSettings);
-const client = { ...clientCMS };
+const client = clientCMS;
 
 client.data.product = (params) => clientPIM.data.product(params);
 client.data.products = (params) => clientPIM.data.products(params);
@@ -23,42 +33,103 @@ client.data.collectionPage = (params) => clientPIM.data.collectionPage(params);
 client.data.allCollections = (params) => clientPIM.data.allCollections(params);
 
 // PREVIEW MODE SETUP
-const previewBranchName = 'preview';
-const vercelBranch = process.env.VERCEL_GITHUB_COMMIT_REF;
-const inPreviewBranch = vercelBranch && vercelBranch === previewBranchName;
-const previewModeToggled =
-  process.env.NACELLE_PREVIEW_MODE === 'true' || inPreviewBranch;
-const previewVariablesExist = Boolean(
-  process.env.CONTENTFUL_PREVIEW_SPACE_ID &&
-    process.env.CONTENTFUL_PREVIEW_API_TOKEN
+const previewModeToggled = process.env.NACELLE_PREVIEW_MODE === 'true';
+
+const pimPreviewVariablesExist = Boolean(
+  process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN && process.env.MYSHOPIFY_DOMAIN
+);
+const cmsPreviewVariablesExist = Boolean(
+  process.env.CONTENTFUL_SPACE_ID && process.env.CONTENTFUL_PREVIEW_API_TOKEN
 );
 
-if (previewModeToggled && !previewVariablesExist) {
-  console.warn(
-    '\nPreview Mode not activated due to missing environment variables:\n' +
-      (!process.env.CONTENTFUL_PREVIEW_SPACE_ID &&
-        '- CONTENTFUL_PREVIEW_SPACE_ID\n') +
-      (!process.env.CONTENTFUL_PREVIEW_API_TOKEN &&
-        '- CONTENTFUL_PREVIEW_API_TOKEN\n')
-  );
-}
+if (previewModeToggled) {
+  if (!pimPreviewVariablesExist || !cmsPreviewVariablesExist) {
+    warnMissingEnvVars([
+      'SHOPIFY_STOREFRONT_ACCESS_TOKEN',
+      'MYSHOPIFY_DOMAIN',
+      'CONTENTFUL_SPACE_ID',
+      'CONTENTFUL_PREVIEW_API_TOKEN'
+    ]);
+  } else {
+    // Initialize the Shopify Preview Connector
+    const shopifyConnector = new NacelleShopifyPreviewConnector({
+      shopifyApiKey: process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN,
+      shopifyDomain: process.env.MYSHOPIFY_DOMAIN.split('.').shift()
+    });
 
-if (previewModeToggled && previewVariablesExist) {
-  // Initialize the Preview Connector
-  // Note: the Contentful Preview API token is not the same as your Content Delivery API token
-  const contentfulPreview = new NacelleContentfulPreviewConnector({
-    contentfulSpaceID: process.env.CONTENTFUL_PREVIEW_SPACE_ID,
-    contentfulToken: process.env.CONTENTFUL_PREVIEW_API_TOKEN
-  });
+    client.data.product = (params) =>
+      params.preview
+        ? shopifyConnector.product(params)
+        : clientPIM.data.product(params);
 
-  client.data.content = (params) => contentfulPreview.content(params);
-  client.data.page = (params) => contentfulPreview.page(params);
-  client.data.pages = (params) => contentfulPreview.pages(params);
-  client.data.article = (params) => contentfulPreview.article(params);
-  client.data.articles = (params) => contentfulPreview.articles(params);
-  client.data.blog = (params) => contentfulPreview.blog(params);
+    client.data.products = (params) =>
+      params.preview
+        ? shopifyConnector.products(params)
+        : clientPIM.data.products(params);
 
-  console.log('\nRUNNING NACELLE IN PREVIEW MODE\n');
+    client.data.collection = (params) =>
+      params.preview
+        ? shopifyConnector.collection(params)
+        : clientPIM.data.collection(params);
+
+    client.data.collectionPage = (params) =>
+      params.preview
+        ? shopifyConnector.collectionPage(params)
+        : clientPIM.data.collectionPage(params);
+
+    client.data.allProducts = (params) =>
+      params?.preview
+        ? shopifyConnector.allProducts(params)
+        : clientPIM.data.allProducts(params);
+
+    client.data.allCollections = (params) =>
+      params?.preview
+        ? shopifyConnector.allCollections(params)
+        : clientPIM.data.allCollections(params);
+
+    // Initialize the Contentful Preview Connector
+    //  NOTE: the Contentful Preview API token is not
+    //  the same as your Content Delivery API token
+    const contentfulPreview = new NacelleContentfulPreviewConnector({
+      contentfulSpaceID: process.env.CONTENTFUL_SPACE_ID,
+      contentfulToken: process.env.CONTENTFUL_PREVIEW_API_TOKEN
+    });
+
+    client.data.content = (params) =>
+      params.preview
+        ? contentfulPreview.content(params)
+        : clientCMS.data.content(params);
+
+    client.data.page = (params) =>
+      params.preview
+        ? contentfulPreview.page(params)
+        : clientCMS.data.page(params);
+
+    client.data.pages = (params) =>
+      params.preview
+        ? contentfulPreview.pages(params)
+        : clientCMS.data.pages(params);
+
+    client.data.article = (params) =>
+      params.preview
+        ? contentfulPreview.article(params)
+        : clientCMS.data.article(params);
+
+    client.data.articles = (params) =>
+      params.preview
+        ? contentfulPreview.articles(params)
+        : clientCMS.data.articles(params);
+
+    client.data.blog = (params) =>
+      params.preview
+        ? contentfulPreview.blog(params)
+        : clientCMS.data.blog(params);
+
+    client.data.allContent = (params) =>
+      params?.preview
+        ? contentfulPreview.allContent(params)
+        : clientCMS.data.allContent(params);
+  }
 }
 
 export default client;

--- a/examples/nextjs/services/nacelle.js
+++ b/examples/nextjs/services/nacelle.js
@@ -23,7 +23,7 @@ const contentfulSettings = { ...settings, locale: process.env.CMS_LOCALE };
 
 const clientPIM = new NacelleClient(shopifySettings);
 const clientCMS = new NacelleClient(contentfulSettings);
-const client = clientCMS;
+const client = new NacelleClient(contentfulSettings);
 
 client.data.product = (params) => clientPIM.data.product(params);
 client.data.products = (params) => clientPIM.data.products(params);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "build": "lerna run build",
     "test:ci": "jest --clearCache && lerna run test:ci",
+    "dev:vercel": "vercel dev",
     "lint": "lerna run lint",
     "clean": "lerna clean",
     "bootstrap": "lerna bootstrap --hoist --nohoist=@nacelle/client-js*",


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

Fixes [NS-539](https://nacelle.atlassian.net/browse/NS-539)

> Nacelle Shopify Connector throwing ECONNREFUSED 127.0.0.1:80 in NextJS

### Type of Change

- [x] Non-breaking feature
- [x] Chore (docs, refactor, etc)

### What is being changed and why?

<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, gifs, etc are appreciated
-->

This PR enables Shopify previews via the [`@nacelle/shopify-connector`](https://www.npmjs.com/package/@nacelle/shopify-connector), and explains the use of new API routes in the README.

#### Demo

https://user-images.githubusercontent.com/5732000/109194151-26ba1c00-7767-11eb-870f-b987042ce2e1.mov

<img width="1792" alt="Screen Shot 2021-02-25 at 10 24 35 AM" src="https://user-images.githubusercontent.com/5732000/109194108-17d36980-7767-11eb-8f97-e0a3bccd919b.png">


### How to Test

<!--
  If applicable, please provide a way to test the changes in a step-by-step manner
-->

visit [`https://nacelle-nextjs-example-git-ns-539-nacelle.vercel.app/api/preview?path=/products/dania-glasses`](https://nacelle-nextjs-example-git-ns-539-nacelle.vercel.app/api/preview?path=/products/dania-glasses)
