### PR TITLE
[packages/react-hooks] Fix useCart bug with un-exported enum

### DIFF
--- a/packages/react-hooks/src/hooks/use-cart/use-cart.types.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.types.ts
@@ -34,7 +34,7 @@ export type CartReducerAction =
   | { type: 'cart/set-status'; payload: CheckoutStatus }
   | { type: 'cart/clear'; payload?: null };
 
-export enum CartToggleStates {
+export const enum CartToggleStates {
   open = 'open',
   closed = 'closed'
 }


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

**Story:** [DD-234](https://nacelle.atlassian.net/browse/DD-234)

> In @nacelle/react-hooks, an enum isn't exported

### Type of Change

- [x] Bug fix

### What is being changed and why?

<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, gifs, etc are appreciated
-->

It turns out that [enums can't be exported directly](https://stackoverflow.com/a/62652759/6387812), and need a variable declaration in order to work as expected. An enum was [added](packages/react-hooks/src/hooks/use-cart/use-cart.types.ts) in #41.

### How to Test

<!--
  If applicable, please provide a way to test the changes in a step-by-step manner
-->

- Checkout the `DD-234` branch
- Build / deploy a site that uses `@nacelle/react-hooks`' `useCart` hook
