### PR TITLE
[packages/react-hooks | v3.0.0] Accept All Supported CheckoutInput Params in useCheckout

### DIFF
--- a/examples/gatsby/src/components/Cart/Cart.js
+++ b/examples/gatsby/src/components/Cart/Cart.js
@@ -17,10 +17,10 @@ const checkoutCredentials = {
 const Cart = () => {
   const [{ cart, show }, cartActions] = useCart();
   const { isMobile } = useDetectDevice();
-  const [checkoutData, checkout, isCheckingOut] = useCheckout(
-    checkoutCredentials,
-    cart
-  );
+  const [checkoutData, checkout, isCheckingOut] = useCheckout({
+    credentials: checkoutCredentials,
+    lineItems: cart
+  });
 
   useEffect(() => {
     if (checkoutData) {

--- a/examples/nextjs/components/Cart/Cart.js
+++ b/examples/nextjs/components/Cart/Cart.js
@@ -18,10 +18,10 @@ const checkoutCredentials = {
 const Cart = () => {
   const [{ cart, show }, cartActions] = useCart();
   const { isMobile } = useDetectDevice();
-  const [checkoutData, checkout, isCheckingOut] = useCheckout(
-    checkoutCredentials,
-    cart
-  );
+  const [checkoutData, checkout, isCheckingOut] = useCheckout({
+    credentials: checkoutCredentials,
+    lineItems: cart
+  });
 
   useEffect(() => {
     if (checkoutData) {

--- a/examples/withRecharge/pages/index.js
+++ b/examples/withRecharge/pages/index.js
@@ -23,10 +23,10 @@ function sanitizeMetafields(metafields) {
 const Home = () => {
   const [cart, setCart] = useState([]);
   const itemMetafields = useRef([]);
-  const [checkoutData, checkout, isCheckingOut] = useCheckout(
-    checkoutCredentials,
-    cart
-  );
+  const [checkoutData, checkout, isCheckingOut] = useCheckout({
+    credentials: checkoutCredentials,
+    lineItems: cart
+  });
 
   useEffect(() => {
     if (

--- a/packages/react-hooks/src/common/types.ts
+++ b/packages/react-hooks/src/common/types.ts
@@ -24,5 +24,6 @@ export interface CheckoutInput {
   metafields?: MetafieldInput[];
   checkoutId?: string;
   note?: string;
+  discountCodes?: string[];
   source?: string;
 }

--- a/packages/react-hooks/src/common/types.ts
+++ b/packages/react-hooks/src/common/types.ts
@@ -1,4 +1,5 @@
 import { Checkout } from '@nacelle/types';
+import { CartItem, MetafieldInput } from '@nacelle/types';
 
 /**
  * @param nacelleSpaceId: the target Nacelle Space ID (string)
@@ -15,4 +16,13 @@ export interface CheckoutResponse {
   data: {
     processCheckout: Checkout;
   };
+}
+
+export interface CheckoutInput {
+  credentials: Credentials;
+  lineItems: CartItem[];
+  metafields?: MetafieldInput[];
+  checkoutId?: string;
+  note?: string;
+  source?: string;
 }

--- a/packages/react-hooks/src/common/types.ts
+++ b/packages/react-hooks/src/common/types.ts
@@ -12,10 +12,19 @@ export interface Credentials {
   nacelleEndpoint: string;
 }
 
+interface CheckoutError {
+  message: string;
+  extensions: {
+    variables: string;
+    field: string;
+    code: string;
+  };
+}
 export interface CheckoutResponse {
   data: {
     processCheckout: Checkout;
   };
+  errors: CheckoutError[];
 }
 
 export interface CheckoutInput {

--- a/packages/react-hooks/src/hooks/use-checkout/use-checkout.test.ts
+++ b/packages/react-hooks/src/hooks/use-checkout/use-checkout.test.ts
@@ -29,7 +29,7 @@ const cartItem = {
   title: shopifyItem.title
 };
 
-const items = [cartItem];
+const lineItems = [cartItem];
 
 const credentials = {
   nacelleSpaceId: 'my-space-id',
@@ -40,6 +40,12 @@ const credentials = {
 describe('useCheckout', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+
+    global.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        json: () => Promise.resolve(checkoutResponse)
+      })
+    );
   });
 
   it('should throw an error if credentials are missing', () => {
@@ -48,17 +54,44 @@ describe('useCheckout', () => {
       nacelleEndpoint: undefined
     };
 
-    expect(() => renderHook(() => useCheckout(badCreds, items))).toThrow();
+    expect(() =>
+      renderHook(() => useCheckout({ credentials: badCreds, lineItems }))
+    ).toThrow();
+  });
+
+  it('should pass optional fields to hail frequency', async () => {
+    const input = {
+      cartItems: lineItems,
+      metafields: [{ key: 'testingTesting', value: '123' }],
+      note: 'please pack with extra bubble wrap',
+      source: 'https://endofie.party/'
+    };
+
+    const { metafields, note, source } = input;
+
+    const { result } = renderHook(() =>
+      useCheckout({ credentials, lineItems, metafields, note, source })
+    );
+    const [, checkout] = result.current;
+
+    await act(async () => {
+      await checkout();
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const bodyCalledWith = JSON.parse(
+      (global.fetch as jest.Mock).mock.calls[0][1].body
+    );
+
+    expect(bodyCalledWith.variables.input.metafields).toEqual(input.metafields);
+    expect(bodyCalledWith.variables.input.note).toEqual(input.note);
+    expect(bodyCalledWith.variables.input.source).toEqual(input.source);
   });
 
   it('should return checkout data from hail frequency', async () => {
-    global.fetch = jest.fn().mockImplementation(() =>
-      Promise.resolve({
-        json: () => Promise.resolve(checkoutResponse)
-      })
+    const { result } = renderHook(() =>
+      useCheckout({ credentials, lineItems })
     );
-
-    const { result } = renderHook(() => useCheckout(credentials, items));
     const [, checkout] = result.current;
 
     expect(result.current[2]).toEqual(false);

--- a/packages/react-hooks/src/hooks/use-checkout/use-checkout.test.ts
+++ b/packages/react-hooks/src/hooks/use-checkout/use-checkout.test.ts
@@ -64,13 +64,21 @@ describe('useCheckout', () => {
       cartItems: lineItems,
       metafields: [{ key: 'testingTesting', value: '123' }],
       note: 'please pack with extra bubble wrap',
-      source: 'https://endofie.party/'
+      source: 'https://endofie.party/',
+      discountCodes: ['2020-was-hard']
     };
 
-    const { metafields, note, source } = input;
+    const { metafields, note, source, discountCodes } = input;
 
     const { result } = renderHook(() =>
-      useCheckout({ credentials, lineItems, metafields, note, source })
+      useCheckout({
+        credentials,
+        lineItems,
+        metafields,
+        note,
+        source,
+        discountCodes
+      })
     );
     const [, checkout] = result.current;
 
@@ -86,6 +94,9 @@ describe('useCheckout', () => {
     expect(bodyCalledWith.variables.input.metafields).toEqual(input.metafields);
     expect(bodyCalledWith.variables.input.note).toEqual(input.note);
     expect(bodyCalledWith.variables.input.source).toEqual(input.source);
+    expect(bodyCalledWith.variables.input.discountCodes).toEqual(
+      input.discountCodes
+    );
   });
 
   it('should return checkout data from hail frequency', async () => {

--- a/packages/react-hooks/src/hooks/use-checkout/use-checkout.ts
+++ b/packages/react-hooks/src/hooks/use-checkout/use-checkout.ts
@@ -81,7 +81,7 @@ export const useCheckout = ({
       variantId: item.id,
       cartItemId: `${idx}::${item.id}`,
       quantity: item.quantity,
-      metafields: item.metafields
+      metafields: item.metafields?.map((m) => ({ key: m.key, value: m.value }))
     }));
 
     if (isCheckingOut) {
@@ -117,7 +117,7 @@ export const useCheckout = ({
 
       if (checkoutResult.errors) {
         throw new Error(
-          `Checkout Errors:\n${JSON.stringify(checkoutResult.errors)}`
+          `Checkout Errors:\n${JSON.stringify(checkoutResult.errors, null, 2)}`
         );
       }
 

--- a/packages/react-hooks/src/hooks/use-checkout/use-checkout.ts
+++ b/packages/react-hooks/src/hooks/use-checkout/use-checkout.ts
@@ -26,11 +26,15 @@ type UseCheckoutResponse = [
  * @property {Object} credentials - an object containing your nacelleEndpoint, nacelleSpaceId, and nacelleGraphqlToken
  * @property {Object[]} lineItems - an array of 'variant' objects containing an 'id' and a 'qty'
  * @property {string} checkoutId - an id string of a previously-created checkout to be continued
+ * @property {Object} metafields - an array of key-value pairs of metadata
+ * @property {string} note - a string representing the order note
+ * @property {string[]} discountCodes - an array of strings representing the discount codes to be applied
+ * @property {string} source - a string representing a URL which is attributed as the source of the checkout
  */
 
 /**
  * @descr Fetch checkout data (url, id, etc.) from the Hail Frequency API
- * @param {CheckoutInput} params - an object containing `credentials` and `lineItems`, plus optional parameters `checkoutId`, `metafields`, `note`, and `source`
+ * @param {CheckoutInput} params - an object containing `credentials` and `lineItems`, plus optional parameters `checkoutId`, `metafields`, `note`, 'discountCodes', and `source`
  *
  * @returns an array with checkout data [0], a checkout callback fn [1], and an isSending boolean [2]
  */
@@ -40,6 +44,7 @@ export const useCheckout = ({
   checkoutId,
   metafields,
   note,
+  discountCodes,
   source
 }: CheckoutInput): UseCheckoutResponse => {
   const [checkoutData, setCheckoutData] = useState<CheckoutResponse | null>(
@@ -91,6 +96,7 @@ export const useCheckout = ({
       checkoutId,
       metafields,
       note,
+      discountCodes,
       source
     };
 
@@ -118,12 +124,13 @@ export const useCheckout = ({
       throw new Error(error);
     }
   }, [
+    credentials,
     cartItems,
     checkoutId,
     metafields,
     note,
+    discountCodes,
     source,
-    credentials,
     isCheckingOut
   ]);
 

--- a/packages/react-hooks/src/hooks/use-checkout/use-checkout.ts
+++ b/packages/react-hooks/src/hooks/use-checkout/use-checkout.ts
@@ -76,14 +76,14 @@ export const useCheckout = ({
     }
   }, [credentials]);
 
-  const cartItems = lineItems.map((item, idx) => ({
-    variantId: item.id,
-    cartItemId: `${idx}::${item.id}`,
-    quantity: item.quantity,
-    metafields: item.metafields
-  }));
-
   const checkout = useCallback(async () => {
+    const cartItems = lineItems.map((item, idx) => ({
+      variantId: item.id,
+      cartItemId: `${idx}::${item.id}`,
+      quantity: item.quantity,
+      metafields: item.metafields
+    }));
+
     if (isCheckingOut) {
       // while sending, don't send again
       return null;
@@ -124,8 +124,8 @@ export const useCheckout = ({
       throw new Error(error);
     }
   }, [
+    lineItems,
     credentials,
-    cartItems,
     checkoutId,
     metafields,
     note,

--- a/packages/react-hooks/src/hooks/use-checkout/use-checkout.ts
+++ b/packages/react-hooks/src/hooks/use-checkout/use-checkout.ts
@@ -115,6 +115,12 @@ export const useCheckout = ({
 
       setCheckoutData(checkoutResult);
 
+      if (checkoutResult.errors) {
+        throw new Error(
+          `Checkout Errors:\n${JSON.stringify(checkoutResult.errors)}`
+        );
+      }
+
       if (isMounted.current) {
         setIsCheckingOut(false); // only update if still mounted
       }


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

**Story:** [DD-290](https://nacelle.atlassian.net/browse/DD-290)

> In @nacelle/react-hooks useCheckout hook, add metafields, note, and source to checkout input params

### Type of Change

- [x] Breaking feature (requires major version bump)

### What is being changed and why?

<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, gifs, etc are appreciated
-->

- Instead of passing an array of `[credentials, lineItems, checkoutId]` to the `useCheckout` hook, pass a `params` object with `{ credentials, lineItems, checkoutId?, metafields?, note?, discountCodes?, source? }`
  -  Previously, `metafields`, `note`, `discountCodes`, and `source` were not accepted by `useCheckout` and sent as `variables` for Hail Frequency's `checkoutProcess` mutation
  - The number of params has grown to the point that they should be passed by name, in an object
    - Changing the input parameters from an array to an object represents a breaking change
- Filters `CheckoutInput.cartItems[idx].metafields` properties to only include `key` and `value`, to maintain compatibility with Hail Frequency v2

#### Demonstration

Given the following code change in `examples/nextjs/components/Cart/Cart.js`:

```js
const [checkoutData, checkout, isCheckingOut] = useCheckout({
  credentials: checkoutCredentials,
  lineItems: cart,
  metafields: [
    { key: 'cavatappi', value: 'swirly boi' },
    { key: 'bucatini', value: 'tubey boi' }
  ],
  note: 'nick sez hey'
});
```

https://user-images.githubusercontent.com/5732000/115797972-2d4dc400-a3a3-11eb-9e91-21c8708f4975.mp4

### How to Test

<!--
  If applicable, please provide a way to test the changes in a step-by-step manner
-->

#### Unit Tests

`cd packages/react-hooks && npm run test:ci`

#### Integration Test

1. `npm run bootstrap` from the monorepo root
2. `cd examples/nextjs`
3. `npm run dev`
4. add some `metafields` or an order `note` in `examples/nextjs/components/Cart/Cart.js`, as shown above
5. add items to cart, complete a checkout, and check the order in Shopify Admin to ensure that the `customAttributes` and `note` are visible in the Order Details

