### PR TITLE
[packages/react-hooks] Added Flexibility for Cart Storage

### DIFF
--- a/examples/gatsby/gatsby-browser.js
+++ b/examples/gatsby/gatsby-browser.js
@@ -16,7 +16,7 @@ export const wrapPageElement = ({ element, props }) => (
 );
 
 export const wrapRootElement = ({ element }) => (
-  <CartProvider useLocalStorage>
+  <CartProvider>
     <CheckoutProvider credentials={checkoutCredentials}>
       <Global styles={styles.global} />
       <ProductSearchProvider>{element}</ProductSearchProvider>

--- a/examples/nextjs/pages/_app.js
+++ b/examples/nextjs/pages/_app.js
@@ -17,7 +17,7 @@ const checkoutCredentials = {
 
 function MyApp({ Component, pageProps, space, products }) {
   return (
-    <CartProvider useLocalStorage>
+    <CartProvider>
       <CheckoutProvider credentials={checkoutCredentials}>
         <Global styles={styles.global} />
         <ProductSearchProvider products={products}>

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -144,7 +144,11 @@ const App = () => {
 };
 ```
 
-By default, the `<CartProvider />` uses Local Storage to persist the cart between refreshes. To disable this, pass `useLocalStorage={false}` as a prop.
+##### Cart Persistence
+
+By default, the `<CartProvider />` uses [Local Storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) to persist the cart between refreshes. If you would prefer to use [Session Storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) instead of Local Storage, pass `storage={'session'}` as a prop. To disable cart storage entirely, pass `storage={null}` as a prop.
+
+When using Local Storage or Session Storage to perist the cart, the default storage key of `'cart'` can be overriden by supplying a `cacheKey="my-custom-cart=key"` prop.
 
 #### The `useCart` Hook
 

--- a/packages/react-hooks/src/hooks/use-cart/actions/addToCart.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/addToCart.ts
@@ -13,7 +13,10 @@ const addToCart: AddToCartFunction = (
     isInCart: action.isInCart || isItemInCart
   });
 
-  setCacheItem(state.useLocalStorage)('cart', JSON.stringify(cart));
+  setCacheItem(action.useLocalStorage, action.useSessionStorage)(
+    action.cacheKey || 'cart',
+    JSON.stringify(cart)
+  );
 
   return {
     ...state,
@@ -29,5 +32,4 @@ export type AddToCartFunction = (
 ) => {
   cart: CartItem[];
   show: boolean;
-  useLocalStorage: boolean;
 };

--- a/packages/react-hooks/src/hooks/use-cart/actions/addToCart.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/addToCart.ts
@@ -13,10 +13,7 @@ const addToCart: AddToCartFunction = (
     isInCart: action.isInCart || isItemInCart
   });
 
-  setCacheItem(action.useLocalStorage, action.useSessionStorage)(
-    action.cacheKey || 'cart',
-    JSON.stringify(cart)
-  );
+  setCacheItem(action.storage)(action.cacheKey || 'cart', JSON.stringify(cart));
 
   return {
     ...state,

--- a/packages/react-hooks/src/hooks/use-cart/actions/clearCart.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/clearCart.ts
@@ -5,12 +5,7 @@ const clearCart: ClearCartFunction = (
   state: CartState,
   action: ClearCartAction
 ) => {
-  if (action.useLocalStorage || action.useSessionStorage) {
-    unsetCacheItem(
-      action.useLocalStorage,
-      action.useSessionStorage
-    )(action.cacheKey || 'cart');
-  }
+  unsetCacheItem(action.storage)(action.cacheKey || 'cart');
 
   return {
     ...state,

--- a/packages/react-hooks/src/hooks/use-cart/actions/clearCart.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/clearCart.ts
@@ -1,8 +1,15 @@
-import { CartState } from '~/hooks/use-cart/use-cart.types';
+import { CartState, ClearCartAction } from '~/hooks/use-cart/use-cart.types';
+import { unsetCacheItem } from '../utils';
 
-const clearCart: ClearCartFunction = (state: CartState) => {
-  if (state.useLocalStorage) {
-    window.localStorage.removeItem('cart');
+const clearCart: ClearCartFunction = (
+  state: CartState,
+  action: ClearCartAction
+) => {
+  if (action.useLocalStorage || action.useSessionStorage) {
+    unsetCacheItem(
+      action.useLocalStorage,
+      action.useSessionStorage
+    )(action.cacheKey || 'cart');
   }
 
   return {
@@ -14,9 +21,9 @@ const clearCart: ClearCartFunction = (state: CartState) => {
 export default clearCart;
 
 export type ClearCartFunction = (
-  state: CartState
+  state: CartState,
+  action: ClearCartAction
 ) => {
   cart: any[];
   show: boolean;
-  useLocalStorage: boolean;
 };

--- a/packages/react-hooks/src/hooks/use-cart/actions/decrementItem.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/decrementItem.ts
@@ -23,10 +23,7 @@ const decrementItem: DecrementItemFunction = (
     return item;
   });
 
-  setCacheItem(action.useLocalStorage, action.useSessionStorage)(
-    action.cacheKey || 'cart',
-    JSON.stringify(cart)
-  );
+  setCacheItem(action.storage)(action.cacheKey || 'cart', JSON.stringify(cart));
 
   return {
     ...state,

--- a/packages/react-hooks/src/hooks/use-cart/actions/decrementItem.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/decrementItem.ts
@@ -23,7 +23,10 @@ const decrementItem: DecrementItemFunction = (
     return item;
   });
 
-  setCacheItem(state.useLocalStorage)('cart', JSON.stringify(cart));
+  setCacheItem(action.useLocalStorage, action.useSessionStorage)(
+    action.cacheKey || 'cart',
+    JSON.stringify(cart)
+  );
 
   return {
     ...state,
@@ -39,5 +42,4 @@ export type DecrementItemFunction = (
 ) => {
   cart: CartItem[];
   show: boolean;
-  useLocalStorage: boolean;
 };

--- a/packages/react-hooks/src/hooks/use-cart/actions/incrementItem.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/incrementItem.ts
@@ -20,10 +20,7 @@ const incrementItem: IncrementItemFunction = (
     return item;
   });
 
-  setCacheItem(action.useLocalStorage, action.useSessionStorage)(
-    action.cacheKey || 'cart',
-    JSON.stringify(cart)
-  );
+  setCacheItem(action.storage)(action.cacheKey || 'cart', JSON.stringify(cart));
 
   return {
     ...state,

--- a/packages/react-hooks/src/hooks/use-cart/actions/incrementItem.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/incrementItem.ts
@@ -20,7 +20,10 @@ const incrementItem: IncrementItemFunction = (
     return item;
   });
 
-  setCacheItem(state.useLocalStorage)('cart', JSON.stringify(cart));
+  setCacheItem(action.useLocalStorage, action.useSessionStorage)(
+    action.cacheKey || 'cart',
+    JSON.stringify(cart)
+  );
 
   return {
     ...state,
@@ -36,5 +39,4 @@ export type IncrementItemFunction = (
 ) => {
   cart: CartItem[];
   show: boolean;
-  useLocalStorage: boolean;
 };

--- a/packages/react-hooks/src/hooks/use-cart/actions/removeFromCart.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/removeFromCart.ts
@@ -16,10 +16,7 @@ const removeFromCart: RemoveFromCartFunction = (
     (item) => item.variant.id !== payloadId
   );
 
-  setCacheItem(action.useLocalStorage, action.useSessionStorage)(
-    action.cacheKey || 'cart',
-    JSON.stringify(cart)
-  );
+  setCacheItem(action.storage)(action.cacheKey || 'cart', JSON.stringify(cart));
 
   return {
     ...state,

--- a/packages/react-hooks/src/hooks/use-cart/actions/removeFromCart.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/removeFromCart.ts
@@ -16,7 +16,10 @@ const removeFromCart: RemoveFromCartFunction = (
     (item) => item.variant.id !== payloadId
   );
 
-  setCacheItem(state.useLocalStorage)('cart', JSON.stringify(cart));
+  setCacheItem(action.useLocalStorage, action.useSessionStorage)(
+    action.cacheKey || 'cart',
+    JSON.stringify(cart)
+  );
 
   return {
     ...state,
@@ -32,5 +35,4 @@ export type RemoveFromCartFunction = (
 ) => {
   cart: CartItem[];
   show: boolean;
-  useLocalStorage: boolean;
 };

--- a/packages/react-hooks/src/hooks/use-cart/actions/toggleCart.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/toggleCart.ts
@@ -34,5 +34,4 @@ export type ToggleCartFunction = (
 ) => {
   show: boolean;
   cart: CartItem[];
-  useLocalStorage: boolean;
 };

--- a/packages/react-hooks/src/hooks/use-cart/actions/updateItem.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/updateItem.ts
@@ -25,10 +25,7 @@ const updateItem: UpdateItemFunction = (
     return localItem || item;
   });
 
-  setCacheItem(action.useLocalStorage, action.useSessionStorage)(
-    action.cacheKey || 'cart',
-    JSON.stringify(cart)
-  );
+  setCacheItem(action.storage)(action.cacheKey || 'cart', JSON.stringify(cart));
 
   return {
     ...state,

--- a/packages/react-hooks/src/hooks/use-cart/actions/updateItem.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/updateItem.ts
@@ -25,7 +25,10 @@ const updateItem: UpdateItemFunction = (
     return localItem || item;
   });
 
-  setCacheItem(state.useLocalStorage)('cart', JSON.stringify(cart));
+  setCacheItem(action.useLocalStorage, action.useSessionStorage)(
+    action.cacheKey || 'cart',
+    JSON.stringify(cart)
+  );
 
   return {
     ...state,
@@ -41,5 +44,4 @@ export type UpdateItemFunction = (
 ) => {
   cart: CartItem[];
   show: boolean;
-  useLocalStorage: boolean;
 };

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.provider.tsx
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.provider.tsx
@@ -31,6 +31,8 @@ export type CartActionContextValue = null | CartActions;
 export type CartProviderProps = {
   children: JSX.Element | JSX.Element[];
   useLocalStorage?: boolean;
+  useSessionStorage?: boolean;
+  cacheKey?: string;
   addToCart?: AddToCartFunction;
   clearCart?: ClearCartFunction;
   decrementItem?: DecrementItemFunction;
@@ -46,7 +48,9 @@ const CartActionContext = React.createContext<CartActionContextValue>(null);
 
 export const CartProvider: FC<CartProviderProps> = ({
   children,
-  useLocalStorage = true,
+  useSessionStorage = true,
+  useLocalStorage = false,
+  cacheKey = 'cart',
   addToCart,
   clearCart,
   decrementItem,
@@ -69,25 +73,66 @@ export const CartProvider: FC<CartProviderProps> = ({
 
   const [state, dispatch] = useReducer(cartReducer, {
     ...initialState,
-    cart,
-    useLocalStorage: useLocalStorage && isClient
+    cart
   });
 
   const cartActions: CartActions = useMemo(
     () => ({
       addToCart: (payload: CartItem): void =>
-        dispatch({ type: ADD_TO_CART, payload, isInCart, addToCart }),
+        dispatch({
+          type: ADD_TO_CART,
+          payload,
+          isInCart,
+          addToCart,
+          useSessionStorage,
+          useLocalStorage,
+          cacheKey
+        }),
       removeFromCart: (payload: CartItem) =>
-        dispatch({ type: REMOVE_FROM_CART, payload, removeFromCart }),
+        dispatch({
+          type: REMOVE_FROM_CART,
+          payload,
+          removeFromCart,
+          useSessionStorage,
+          useLocalStorage,
+          cacheKey
+        }),
       updateItem: (payload: CartItem) =>
-        dispatch({ type: UPDATE_ITEM, payload, updateItem }),
+        dispatch({
+          type: UPDATE_ITEM,
+          payload,
+          updateItem,
+          useSessionStorage,
+          useLocalStorage,
+          cacheKey
+        }),
       incrementItem: (payload: CartItem): void =>
-        dispatch({ type: INCREMENT_ITEM, payload, incrementItem }),
+        dispatch({
+          type: INCREMENT_ITEM,
+          payload,
+          incrementItem,
+          useSessionStorage,
+          useLocalStorage,
+          cacheKey
+        }),
       decrementItem: (payload: CartItem): void =>
-        dispatch({ type: DECREMENT_ITEM, payload, decrementItem }),
+        dispatch({
+          type: DECREMENT_ITEM,
+          payload,
+          decrementItem,
+          useSessionStorage,
+          useLocalStorage,
+          cacheKey
+        }),
       toggleCart: (payload: CartToggleStates) =>
         dispatch({ type: TOGGLE_CART, payload, toggleCart }),
-      clearCart: (): void => dispatch({ type: CLEAR_CART, clearCart })
+      clearCart: (): void =>
+        dispatch({
+          type: CLEAR_CART,
+          clearCart,
+          useSessionStorage,
+          useLocalStorage
+        })
     }),
     [
       isInCart,
@@ -97,7 +142,10 @@ export const CartProvider: FC<CartProviderProps> = ({
       incrementItem,
       decrementItem,
       toggleCart,
-      clearCart
+      clearCart,
+      useSessionStorage,
+      useLocalStorage,
+      cacheKey
     ]
   );
 

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.provider.tsx
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.provider.tsx
@@ -12,7 +12,8 @@ import {
   RemoveFromCartFunction,
   ToggleCartFunction,
   UpdateItemFunction,
-  IsInCartFunction
+  IsInCartFunction,
+  StorageTypes
 } from './use-cart.types';
 
 import cartReducer, {
@@ -30,8 +31,7 @@ export type CartContextValue = null | CartState;
 export type CartActionContextValue = null | CartActions;
 export type CartProviderProps = {
   children: JSX.Element | JSX.Element[];
-  useLocalStorage?: boolean;
-  useSessionStorage?: boolean;
+  storage?: StorageTypes;
   cacheKey?: string;
   addToCart?: AddToCartFunction;
   clearCart?: ClearCartFunction;
@@ -48,8 +48,7 @@ const CartActionContext = React.createContext<CartActionContextValue>(null);
 
 export const CartProvider: FC<CartProviderProps> = ({
   children,
-  useSessionStorage = true,
-  useLocalStorage = false,
+  storage = 'local',
   cacheKey = 'cart',
   addToCart,
   clearCart,
@@ -60,11 +59,19 @@ export const CartProvider: FC<CartProviderProps> = ({
   updateItem,
   isInCart
 }) => {
-  const isClient = typeof window !== 'undefined';
   let cart = [];
+  const isClient = typeof window !== 'undefined';
 
-  if (useLocalStorage && isClient) {
-    const cartString = window.localStorage.getItem('cart');
+  if (isClient) {
+    let cartString: string | null = '';
+
+    if (storage) {
+      if (storage === 'local') {
+        cartString = window.localStorage.getItem(cacheKey);
+      } else if (storage === 'session') {
+        cartString = window.sessionStorage.getItem(cacheKey);
+      }
+    }
 
     if (cartString) {
       cart = JSON.parse(cartString);
@@ -84,8 +91,7 @@ export const CartProvider: FC<CartProviderProps> = ({
           payload,
           isInCart,
           addToCart,
-          useSessionStorage,
-          useLocalStorage,
+          storage,
           cacheKey
         }),
       removeFromCart: (payload: CartItem) =>
@@ -93,8 +99,7 @@ export const CartProvider: FC<CartProviderProps> = ({
           type: REMOVE_FROM_CART,
           payload,
           removeFromCart,
-          useSessionStorage,
-          useLocalStorage,
+          storage,
           cacheKey
         }),
       updateItem: (payload: CartItem) =>
@@ -102,8 +107,7 @@ export const CartProvider: FC<CartProviderProps> = ({
           type: UPDATE_ITEM,
           payload,
           updateItem,
-          useSessionStorage,
-          useLocalStorage,
+          storage,
           cacheKey
         }),
       incrementItem: (payload: CartItem): void =>
@@ -111,8 +115,7 @@ export const CartProvider: FC<CartProviderProps> = ({
           type: INCREMENT_ITEM,
           payload,
           incrementItem,
-          useSessionStorage,
-          useLocalStorage,
+          storage,
           cacheKey
         }),
       decrementItem: (payload: CartItem): void =>
@@ -120,8 +123,7 @@ export const CartProvider: FC<CartProviderProps> = ({
           type: DECREMENT_ITEM,
           payload,
           decrementItem,
-          useSessionStorage,
-          useLocalStorage,
+          storage,
           cacheKey
         }),
       toggleCart: (payload: CartToggleStates) =>
@@ -130,8 +132,7 @@ export const CartProvider: FC<CartProviderProps> = ({
         dispatch({
           type: CLEAR_CART,
           clearCart,
-          useSessionStorage,
-          useLocalStorage
+          storage
         })
     }),
     [
@@ -143,8 +144,7 @@ export const CartProvider: FC<CartProviderProps> = ({
       decrementItem,
       toggleCart,
       clearCart,
-      useSessionStorage,
-      useLocalStorage,
+      storage,
       cacheKey
     ]
   );

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.test.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.test.ts
@@ -53,8 +53,7 @@ describe('useCart reducer', () => {
       const result = cartReducer(initialState, {
         type: ADD_TO_CART,
         payload: cartItem,
-        useLocalStorage: false,
-        useSessionStorage: false,
+        storage: null,
         cacheKey: 'cart'
       });
       expect(result.cart).toEqual([cartItem]);
@@ -64,8 +63,7 @@ describe('useCart reducer', () => {
       const result = cartReducer(initialState, {
         type: ADD_TO_CART,
         payload: cartItem,
-        useLocalStorage: false,
-        useSessionStorage: false,
+        storage: null,
         cacheKey: 'cart'
       });
       expect(result.cart[0].product).toHaveProperty('metafields');
@@ -85,8 +83,7 @@ describe('useCart reducer', () => {
       const result = cartReducer(cartState, {
         type: ADD_TO_CART,
         payload: cartItem,
-        useLocalStorage: false,
-        useSessionStorage: false,
+        storage: null,
         cacheKey: 'cart'
       });
 
@@ -99,8 +96,7 @@ describe('useCart reducer', () => {
         {
           type: ADD_TO_CART,
           payload: cartItem,
-          useLocalStorage: true,
-          useSessionStorage: false,
+          storage: 'local',
           cacheKey: 'cart'
         }
       );
@@ -115,13 +111,42 @@ describe('useCart reducer', () => {
         {
           type: ADD_TO_CART,
           payload: cartItem,
-          useLocalStorage: false,
-          useSessionStorage: true,
+          storage: 'session',
           cacheKey: 'cart'
         }
       );
       expect(
         JSON.parse(window.sessionStorage.getItem('cart') as string)
+      ).toEqual([cartItem]);
+    });
+
+    it('should add to item localStorage cart using custom cacheKey', () => {
+      cartReducer(
+        { ...initialState },
+        {
+          type: ADD_TO_CART,
+          payload: cartItem,
+          storage: 'local',
+          cacheKey: 'new-cart'
+        }
+      );
+      expect(
+        JSON.parse(window.localStorage.getItem('new-cart') as string)
+      ).toEqual([cartItem]);
+    });
+
+    it('should add to item sessionStorage cart using custom cacheKey', () => {
+      cartReducer(
+        { ...initialState },
+        {
+          type: ADD_TO_CART,
+          payload: cartItem,
+          storage: 'session',
+          cacheKey: 'new-cart'
+        }
+      );
+      expect(
+        JSON.parse(window.sessionStorage.getItem('new-cart') as string)
       ).toEqual([cartItem]);
     });
   });
@@ -143,8 +168,7 @@ describe('useCart reducer', () => {
             title: 'Updated Title'
           }
         },
-        useLocalStorage: false,
-        useSessionStorage: false,
+        storage: null,
         cacheKey: 'cart'
       });
 
@@ -172,8 +196,7 @@ describe('useCart reducer', () => {
           },
           quantity: 10
         },
-        useLocalStorage: true,
-        useSessionStorage: false,
+        storage: 'local',
         cacheKey: 'cart'
       });
 
@@ -203,20 +226,19 @@ describe('useCart reducer', () => {
           },
           quantity: 10
         },
-        useLocalStorage: false,
-        useSessionStorage: true,
+        storage: 'session',
         cacheKey: 'cart'
       });
 
-      expect(JSON.parse(window.localStorage.getItem('cart') as string)).toEqual(
-        [
-          {
-            ...cartItem,
-            quantity: 10,
-            product: { ...cartItem.product, title: 'Updated Title' }
-          }
-        ]
-      );
+      expect(
+        JSON.parse(window.sessionStorage.getItem('cart') as string)
+      ).toEqual([
+        {
+          ...cartItem,
+          quantity: 10,
+          product: { ...cartItem.product, title: 'Updated Title' }
+        }
+      ]);
     });
   });
 
@@ -230,8 +252,7 @@ describe('useCart reducer', () => {
       const result = cartReducer(cartState, {
         type: REMOVE_FROM_CART,
         payload: cartItem,
-        useLocalStorage: false,
-        useSessionStorage: false,
+        storage: null,
         cacheKey: 'cart'
       });
 
@@ -247,8 +268,7 @@ describe('useCart reducer', () => {
       cartReducer(cartState, {
         type: REMOVE_FROM_CART,
         payload: cartItem,
-        useLocalStorage: true,
-        useSessionStorage: false,
+        storage: 'local',
         cacheKey: 'cart'
       });
 
@@ -266,8 +286,7 @@ describe('useCart reducer', () => {
       cartReducer(cartState, {
         type: REMOVE_FROM_CART,
         payload: cartItem,
-        useLocalStorage: false,
-        useSessionStorage: true,
+        storage: 'session',
         cacheKey: 'cart'
       });
 
@@ -287,8 +306,7 @@ describe('useCart reducer', () => {
       const result = cartReducer(cartState, {
         type: INCREMENT_ITEM,
         payload: cartItem,
-        useLocalStorage: false,
-        useSessionStorage: false,
+        storage: null,
         cacheKey: 'cart'
       });
 
@@ -306,8 +324,7 @@ describe('useCart reducer', () => {
       cartReducer(cartState, {
         type: INCREMENT_ITEM,
         payload: cartItem,
-        useLocalStorage: true,
-        useSessionStorage: false,
+        storage: 'local',
         cacheKey: 'cart'
       });
 
@@ -325,8 +342,7 @@ describe('useCart reducer', () => {
       cartReducer(cartState, {
         type: INCREMENT_ITEM,
         payload: cartItem,
-        useLocalStorage: false,
-        useSessionStorage: true,
+        storage: 'session',
         cacheKey: 'cart'
       });
 
@@ -346,8 +362,7 @@ describe('useCart reducer', () => {
       const result = cartReducer(cartState, {
         type: DECREMENT_ITEM,
         payload: cartItem,
-        useLocalStorage: false,
-        useSessionStorage: false,
+        storage: null,
         cacheKey: 'cart'
       });
 
@@ -363,8 +378,7 @@ describe('useCart reducer', () => {
       const result = cartReducer(cartState, {
         type: DECREMENT_ITEM,
         payload: cartItem,
-        useLocalStorage: false,
-        useSessionStorage: false,
+        storage: null,
         cacheKey: 'cart'
       });
 
@@ -380,8 +394,7 @@ describe('useCart reducer', () => {
       cartReducer(cartState, {
         type: DECREMENT_ITEM,
         payload: cartItem,
-        useLocalStorage: true,
-        useSessionStorage: false,
+        storage: 'local',
         cacheKey: 'cart'
       });
 
@@ -399,8 +412,7 @@ describe('useCart reducer', () => {
       cartReducer(cartState, {
         type: DECREMENT_ITEM,
         payload: cartItem,
-        useLocalStorage: false,
-        useSessionStorage: true,
+        storage: 'session',
         cacheKey: 'cart'
       });
 
@@ -419,8 +431,7 @@ describe('useCart reducer', () => {
 
       const result = cartReducer(cartState, {
         type: CLEAR_CART,
-        useLocalStorage: false,
-        useSessionStorage: false,
+        storage: null,
         cacheKey: 'cart'
       });
 

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.ts
@@ -32,8 +32,7 @@ export const CLEAR_CART = 'cart/clear';
 
 export const initialState: CartState = {
   cart: [],
-  show: false,
-  useLocalStorage: true
+  show: false
 };
 
 export interface CreateCartReducerParams {
@@ -84,8 +83,8 @@ const cartReducer = (
 
     case CLEAR_CART:
       return action.clearCart
-        ? action.clearCart(state)
-        : clearCartDefault(state);
+        ? action.clearCart(state, action)
+        : clearCartDefault(state, action);
 
     case TOGGLE_CART: {
       return action.toggleCart

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.types.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.types.ts
@@ -10,7 +10,6 @@ import { UpdateItemFunction } from './actions/updateItem';
 export type CartState = {
   cart: CartItem[];
   show: boolean;
-  useLocalStorage: boolean;
 };
 
 export type IsInCartFunction = (cart: CartItem[], payload: CartItem) => boolean;
@@ -34,6 +33,9 @@ export type CartActions = {
 export type AddToCartAction = {
   type: 'cart/add-to-cart';
   payload: CartItem;
+  useSessionStorage: boolean;
+  useLocalStorage: boolean;
+  cacheKey: string;
   addToCart?: AddToCartFunction;
   isInCart?: IsInCartFunction;
 };
@@ -41,24 +43,36 @@ export type AddToCartAction = {
 export type UpdateItemAction = {
   type: 'cart/update-item';
   payload: CartItem;
+  useSessionStorage: boolean;
+  useLocalStorage: boolean;
+  cacheKey: string;
   updateItem?: UpdateItemFunction;
 };
 
 export type IncrementItemAction = {
   type: 'cart/increment-item';
   payload: CartItem;
+  useSessionStorage: boolean;
+  useLocalStorage: boolean;
+  cacheKey: string;
   incrementItem?: IncrementItemFunction;
 };
 
 export type DecrementItemAction = {
   type: 'cart/decrement-item';
   payload: CartItem;
+  useSessionStorage: boolean;
+  useLocalStorage: boolean;
+  cacheKey: string;
   decrementItem?: DecrementItemFunction;
 };
 
 export type RemoveFromCartAction = {
   type: 'cart/remove-from-cart';
   payload: CartItem;
+  useSessionStorage: boolean;
+  useLocalStorage: boolean;
+  cacheKey: string;
   removeFromCart?: RemoveFromCartFunction;
 };
 
@@ -71,6 +85,9 @@ export type ToggleVisibilityAction = {
 export type ClearCartAction = {
   type: 'cart/clear';
   clearCart?: ClearCartFunction;
+  useSessionStorage: boolean;
+  useLocalStorage: boolean;
+  cacheKey?: string;
 };
 
 export type CartReducerAction =

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.types.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.types.ts
@@ -33,8 +33,7 @@ export type CartActions = {
 export type AddToCartAction = {
   type: 'cart/add-to-cart';
   payload: CartItem;
-  useSessionStorage: boolean;
-  useLocalStorage: boolean;
+  storage: StorageTypes;
   cacheKey: string;
   addToCart?: AddToCartFunction;
   isInCart?: IsInCartFunction;
@@ -43,8 +42,7 @@ export type AddToCartAction = {
 export type UpdateItemAction = {
   type: 'cart/update-item';
   payload: CartItem;
-  useSessionStorage: boolean;
-  useLocalStorage: boolean;
+  storage: StorageTypes;
   cacheKey: string;
   updateItem?: UpdateItemFunction;
 };
@@ -52,8 +50,7 @@ export type UpdateItemAction = {
 export type IncrementItemAction = {
   type: 'cart/increment-item';
   payload: CartItem;
-  useSessionStorage: boolean;
-  useLocalStorage: boolean;
+  storage: StorageTypes;
   cacheKey: string;
   incrementItem?: IncrementItemFunction;
 };
@@ -61,8 +58,7 @@ export type IncrementItemAction = {
 export type DecrementItemAction = {
   type: 'cart/decrement-item';
   payload: CartItem;
-  useSessionStorage: boolean;
-  useLocalStorage: boolean;
+  storage: StorageTypes;
   cacheKey: string;
   decrementItem?: DecrementItemFunction;
 };
@@ -70,8 +66,7 @@ export type DecrementItemAction = {
 export type RemoveFromCartAction = {
   type: 'cart/remove-from-cart';
   payload: CartItem;
-  useSessionStorage: boolean;
-  useLocalStorage: boolean;
+  storage: StorageTypes;
   cacheKey: string;
   removeFromCart?: RemoveFromCartFunction;
 };
@@ -85,8 +80,7 @@ export type ToggleVisibilityAction = {
 export type ClearCartAction = {
   type: 'cart/clear';
   clearCart?: ClearCartFunction;
-  useSessionStorage: boolean;
-  useLocalStorage: boolean;
+  storage: StorageTypes;
   cacheKey?: string;
 };
 
@@ -105,6 +99,15 @@ const cartToggleStates = {
 } as const;
 
 export type CartToggleStates = typeof cartToggleStates[keyof typeof cartToggleStates];
+
+const storageTypes = {
+  session: 'session',
+  local: 'local'
+} as const;
+
+export type StorageTypes =
+  | typeof storageTypes[keyof typeof storageTypes]
+  | null;
 
 export type { AddToCartFunction } from './actions/addToCart';
 export type { ClearCartFunction } from './actions/clearCart';

--- a/packages/react-hooks/src/hooks/use-cart/utils/index.ts
+++ b/packages/react-hooks/src/hooks/use-cart/utils/index.ts
@@ -46,14 +46,32 @@ export function buildCart({
     : [...cart, { ...payload }];
 }
 
-export function setCacheItem(useLocalStorage: boolean) {
-  return useLocalStorage
-    ? window.localStorage.setItem.bind(localStorage)
-    : () => {};
+export function setCacheItem(
+  useLocalStorage: boolean,
+  useSessionStorage: boolean
+) {
+  if (useLocalStorage) {
+    return window.localStorage.setItem.bind(localStorage);
+  }
+
+  if (useSessionStorage) {
+    return window.sessionStorage.setItem.bind(sessionStorage);
+  }
+
+  return () => {};
 }
 
-export function unsetCacheItem(useLocalStorage: boolean) {
-  return useLocalStorage
-    ? window.localStorage.removeItem.bind(localStorage)
-    : () => {};
+export function unsetCacheItem(
+  useLocalStorage: boolean,
+  useSessionStorage: boolean
+) {
+  if (useLocalStorage) {
+    return window.localStorage.removeItem.bind(localStorage);
+  }
+
+  if (useSessionStorage) {
+    return window.sessionStorage.removeItem.bind(sessionStorage);
+  }
+
+  return () => {};
 }

--- a/packages/react-hooks/src/hooks/use-cart/utils/index.ts
+++ b/packages/react-hooks/src/hooks/use-cart/utils/index.ts
@@ -1,6 +1,6 @@
 import { CartItem } from '../../common/types';
 
-import { IsInCartFunction } from '../use-cart.types';
+import { IsInCartFunction, StorageTypes } from '../use-cart.types';
 
 /**
  * A utility function which will return true if the item is already in the cart
@@ -46,30 +46,20 @@ export function buildCart({
     : [...cart, { ...payload }];
 }
 
-export function setCacheItem(
-  useLocalStorage: boolean,
-  useSessionStorage: boolean
-) {
-  if (useLocalStorage) {
+export function setCacheItem(storage: StorageTypes | null) {
+  if (storage === 'local') {
     return window.localStorage.setItem.bind(localStorage);
-  }
-
-  if (useSessionStorage) {
+  } else if (storage === 'session') {
     return window.sessionStorage.setItem.bind(sessionStorage);
   }
 
   return () => {};
 }
 
-export function unsetCacheItem(
-  useLocalStorage: boolean,
-  useSessionStorage: boolean
-) {
-  if (useLocalStorage) {
+export function unsetCacheItem(storage: StorageTypes | null) {
+  if (storage === 'local') {
     return window.localStorage.removeItem.bind(localStorage);
-  }
-
-  if (useSessionStorage) {
+  } else if (storage === 'session') {
     return window.sessionStorage.removeItem.bind(sessionStorage);
   }
 


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

**Story:** [DD-428](https://nacelle.atlassian.net/browse/DD-428)

> As a merchant developer, I want to be able to customize @nacelle/react-hooks' use of the Storage API, so that I have more control of my customer's cart persistence

### Type of Change

- [x] Breaking feature (requires bump to next major version)

### What is being changed and why?

#### Allow Custom Storage Key

_Non-Breaking Change_

When persisting the cart in browser storage, the key `'cart'` was used, without any ability to control the key name. This can cause headaches when migrating from `@nacelle/react-hooks@3.x`, which formatted `CartItems`s differently.

This change allows merchant developers to upgrade from  `@nacelle/react-hooks@3.x` without creating any collisions between mis-matched carts in `localStorage`, for example, when customers who have an older cart saved in their `localStorage`.

##### Demonstration

https://user-images.githubusercontent.com/5732000/117478517-43c05780-af2d-11eb-8c7f-90d5739eb6d2.mov

#### New Session Storage Option

_Breaking Change_

Allows the merchant developer to persist the cart with [Session Storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) instead of Local Storage. The breaking change comes from the removal of the `<CartProvider />`'s `useLocalStorage` prop, in favor of a `storage` prop, which can receive `'local'`, `'session'`, or `null`.

<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, gifs, etc are appreciated
-->

##### Demonstration

https://user-images.githubusercontent.com/5732000/117479207-0a3c1c00-af2e-11eb-8a20-7ebb98110856.mov

### How to Test

<!--
  If applicable, please provide a way to test the changes in a step-by-step manner
-->

From the monorepo root:

1. Unit Tests
- `npm run bootstrap`
- `cd packges/react-hooks && npm run test:ci`

2. Example Projects
- go to either `examples/nextjs` or `examples/gatsby` and `npm run dev`
- in the App's root (either `examples/nextjs/pages/_app.js` or `examples/gatsby/gatsby-browser.js`), experiment with the `<CartProvider />`'s `cacheKey` and `storage` props
- add some items to the cart, remove them, update their quantity, etc. and verify that changes are made in either Local Storage or Session Storage
