### PR TITLE
[packages/react-hooks] Add Support for Legacy Cart Items in Browser Storage

### DIFF
--- a/examples/gatsby/src/components/Cart/Cart.js
+++ b/examples/gatsby/src/components/Cart/Cart.js
@@ -39,10 +39,10 @@ const Cart = () => {
         </Button>
       </header>
       <section css={styles.cartItems}>
-        {cart.map((item) => (
+        {cart.map((item, idx) => (
           <CartItem
             item={item}
-            key={item.id}
+            key={`${idx}::${item.id}`}
             cartActions={cartActions}
             isMobile={isMobile}
           />

--- a/examples/gatsby/src/components/Cart/Cart.js
+++ b/examples/gatsby/src/components/Cart/Cart.js
@@ -97,6 +97,10 @@ const CartItem = ({ item, cartActions, isMobile }) => {
   };
 
   const removeItemFromCart = () => cartActions.removeFromCart(item);
+  const { featuredMedia: variantMedia } = item.variant;
+  const { featuredMedia: productMedia } = item.product;
+  const altText =
+    variantMedia.altText || productMedia.altText || item.product.title;
 
   return (
     <div css={styles.cartItem}>
@@ -106,8 +110,8 @@ const CartItem = ({ item, cartActions, isMobile }) => {
       >
         <Image
           styles={styles.cartItemThumbnail}
-          src={item.product.featuredMedia.thumbnailSrc}
-          alt={item.product.featuredMedia.altText || item.product.title}
+          src={variantMedia.thumbnailSrc || productMedia.thumbnailSrc}
+          alt={altText}
         />
       </Link>
 

--- a/examples/gatsby/src/components/ProductGallery/ProductGallery.js
+++ b/examples/gatsby/src/components/ProductGallery/ProductGallery.js
@@ -12,10 +12,13 @@ const ProductGallery = ({ products }) => {
       styles={styles.grid}
     >
       {products.map(
-        (product) =>
+        (product, idx) =>
           product &&
           product.variants && (
-            <ProductCard product={product} key={product.remoteId} />
+            <ProductCard
+              product={product}
+              key={`${idx}::${product.remoteId}`}
+            />
           )
       )}
     </Grid>

--- a/examples/gatsby/src/providers/ProductSearch.js
+++ b/examples/gatsby/src/providers/ProductSearch.js
@@ -115,11 +115,13 @@ function createSearchFilters(products) {
 function addFacetsToProducts(products) {
   return products.map(({ tags, variants, productType, ...product }) => {
     const variantFacets = variants
-      ?.map((variant) =>
-        variant.selectedOptions.filter((option) => option.name !== 'Title')
-      )
-      .reduce((filters, option) => filters.concat(option))
-      .map((option) => ({ ...option, name: option.name.toLowerCase() }));
+      ? variants
+          .map((variant) =>
+            variant.selectedOptions.filter((option) => option.name !== 'Title')
+          )
+          .reduce((filters, option) => filters.concat(option))
+          .map((option) => ({ ...option, name: option.name.toLowerCase() }))
+      : [];
 
     const tagFacets = tags
       ?.filter((tag) => tag.includes('filter'))

--- a/examples/gatsby/src/providers/ProductSearch.js
+++ b/examples/gatsby/src/providers/ProductSearch.js
@@ -115,7 +115,7 @@ function createSearchFilters(products) {
 function addFacetsToProducts(products) {
   return products.map(({ tags, variants, productType, ...product }) => {
     const variantFacets = variants
-      .map((variant) =>
+      ?.map((variant) =>
         variant.selectedOptions.filter((option) => option.name !== 'Title')
       )
       .reduce((filters, option) => filters.concat(option))

--- a/examples/gatsby/src/providers/ProductSearch.js
+++ b/examples/gatsby/src/providers/ProductSearch.js
@@ -124,19 +124,21 @@ function addFacetsToProducts(products) {
       : [];
 
     const tagFacets = tags
-      ?.filter((tag) => tag.includes('filter'))
-      .reduce((filters, tag) => {
-        const [, name, tagValues] = tag.split('_');
-        const values = tagValues
-          ?.split('-')
-          .map(
-            (fragment) =>
-              `${fragment.charAt(0).toUpperCase()}${fragment.substring(1)}`
-          )
-          .join(' ');
+      ? tags
+          .filter((tag) => tag.includes('filter'))
+          .reduce((filters, tag) => {
+            const [, name, tagValues] = tag.split('_');
+            const values = tagValues
+              ?.split('-')
+              .map(
+                (fragment) =>
+                  `${fragment.charAt(0).toUpperCase()}${fragment.substring(1)}`
+              )
+              .join(' ');
 
-        return [...filters, { name, value: values }];
-      }, []);
+            return [...filters, { name, value: values }];
+          }, [])
+      : [];
 
     return {
       ...product,

--- a/examples/gatsby/src/providers/ProductSearch.js
+++ b/examples/gatsby/src/providers/ProductSearch.js
@@ -38,6 +38,8 @@ export const ProductSearchProvider = ({ children }) => {
                 thumbnailSrc
                 altText
               }
+              price
+              priceCurrency
             }
           }
         }
@@ -120,11 +122,11 @@ function addFacetsToProducts(products) {
       .map((option) => ({ ...option, name: option.name.toLowerCase() }));
 
     const tagFacets = tags
-      .filter((tag) => tag.includes('filter'))
+      ?.filter((tag) => tag.includes('filter'))
       .reduce((filters, tag) => {
         const [, name, tagValues] = tag.split('_');
         const values = tagValues
-          .split('-')
+          ?.split('-')
           .map(
             (fragment) =>
               `${fragment.charAt(0).toUpperCase()}${fragment.substring(1)}`

--- a/examples/nextjs/components/Cart/Cart.js
+++ b/examples/nextjs/components/Cart/Cart.js
@@ -100,13 +100,18 @@ const CartItem = ({ item, cartActions, isMobile }) => {
   };
 
   const removeItemFromCart = () => cartActions.removeFromCart(item);
+  const { featuredMedia: variantMedia } = item.variant;
+  const { featuredMedia: productMedia } = item.product;
+  const altText =
+    variantMedia.altText || productMedia.altText || item.product.title;
 
   return (
     <div css={styles.cartItem}>
       <Link href={`/products/${item.product.handle}`}>
         <a css={[styles.thumbnailContainer, isMobile && { paddingLeft: 0 }]}>
           <Image
-            src={item.product.featuredMedia.thumbnailSrc}
+            src={variantMedia.thumbnailSrc || productMedia.thumbnailSrc}
+            alt={altText}
             width="100"
             height="70"
             css={styles.cartItemThumbnail}

--- a/examples/nextjs/components/Cart/Cart.js
+++ b/examples/nextjs/components/Cart/Cart.js
@@ -45,7 +45,7 @@ const Cart = () => {
         {cart.map((item, idx) => (
           <CartItem
             item={item}
-            key={`${item.variant.id}::${idx}`}
+            key={`${idx}::${item.variant.id}`}
             cartActions={cartActions}
             isMobile={isMobile}
           />

--- a/examples/nextjs/components/ProductGallery/ProductGallery.js
+++ b/examples/nextjs/components/ProductGallery/ProductGallery.js
@@ -11,10 +11,10 @@ const ProductGallery = ({ products }) => {
       columns="repeat(auto-fit, minmax(20em, 1fr))"
       styles={styles.grid}
     >
-      {products.map((product) => (
+      {products.map((product, idx) => (
         <ProductCard
           product={product}
-          key={product.id}
+          key={`${idx}::${product.remoteId}`}
           width={320}
           height={240}
         />

--- a/examples/nextjs/providers/ProductSearch.js
+++ b/examples/nextjs/providers/ProductSearch.js
@@ -70,11 +70,13 @@ function createSearchFilters(products) {
 function addFacetsToProducts(products) {
   return products.map(({ tags, variants, productType, ...product }) => {
     const variantFacets = variants
-      ?.map((variant) =>
-        variant.selectedOptions.filter((option) => option.name !== 'Title')
-      )
-      .reduce((filters, option) => filters.concat(option))
-      .map((option) => ({ ...option, name: option.name.toLowerCase() }));
+      ? variants
+          .map((variant) =>
+            variant.selectedOptions.filter((option) => option.name !== 'Title')
+          )
+          .reduce((filters, option) => filters.concat(option))
+          .map((option) => ({ ...option, name: option.name.toLowerCase() }))
+      : [];
 
     const tagFacets = tags
       ?.filter((tag) => tag.includes('filter'))

--- a/examples/nextjs/providers/ProductSearch.js
+++ b/examples/nextjs/providers/ProductSearch.js
@@ -70,7 +70,7 @@ function createSearchFilters(products) {
 function addFacetsToProducts(products) {
   return products.map(({ tags, variants, productType, ...product }) => {
     const variantFacets = variants
-      .map((variant) =>
+      ?.map((variant) =>
         variant.selectedOptions.filter((option) => option.name !== 'Title')
       )
       .reduce((filters, option) => filters.concat(option))

--- a/examples/nextjs/providers/ProductSearch.js
+++ b/examples/nextjs/providers/ProductSearch.js
@@ -77,11 +77,11 @@ function addFacetsToProducts(products) {
       .map((option) => ({ ...option, name: option.name.toLowerCase() }));
 
     const tagFacets = tags
-      .filter((tag) => tag.includes('filter'))
+      ?.filter((tag) => tag.includes('filter'))
       .reduce((filters, tag) => {
         const [, name, tagValues] = tag.split('_');
         const values = tagValues
-          .split('-')
+          ?.split('-')
           .map(
             (fragment) =>
               `${fragment.charAt(0).toUpperCase()}${fragment.substring(1)}`

--- a/examples/nextjs/providers/ProductSearch.js
+++ b/examples/nextjs/providers/ProductSearch.js
@@ -79,19 +79,21 @@ function addFacetsToProducts(products) {
       : [];
 
     const tagFacets = tags
-      ?.filter((tag) => tag.includes('filter'))
-      .reduce((filters, tag) => {
-        const [, name, tagValues] = tag.split('_');
-        const values = tagValues
-          ?.split('-')
-          .map(
-            (fragment) =>
-              `${fragment.charAt(0).toUpperCase()}${fragment.substring(1)}`
-          )
-          .join(' ');
+      ? tags
+          .filter((tag) => tag.includes('filter'))
+          .reduce((filters, tag) => {
+            const [, name, tagValues] = tag.split('_');
+            const values = tagValues
+              ?.split('-')
+              .map(
+                (fragment) =>
+                  `${fragment.charAt(0).toUpperCase()}${fragment.substring(1)}`
+              )
+              .join(' ');
 
-        return [...filters, { name, value: values }];
-      }, []);
+            return [...filters, { name, value: values }];
+          }, [])
+      : [];
 
     return {
       ...product,

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "@testing-library/react-hooks": "^3.4.1",
     "@types/jest": "^26.0.9",
     "@types/react": "^16.9.46",
-    "@typescript-eslint/eslint-plugin": "^3.9.0",
-    "@typescript-eslint/parser": "^3.9.0",
+    "@typescript-eslint/eslint-plugin": "^4.23.0",
+    "@typescript-eslint/parser": "^4.23.0",
     "babel-jest": "^26.3.0",
     "boxen": "^4.2.0",
     "chalk": "^4.1.0",
@@ -48,7 +48,7 @@
     "lerna": "^3.22.1",
     "lint-staged": "^10.2.11",
     "listr2": "^3.1.1",
-    "next": "^10.1.3",
+    "next": "^10.2.0",
     "node-emoji": "^1.10.0",
     "prettier": "^2.1.2",
     "react": "^16.13.1",
@@ -61,7 +61,8 @@
     "rollup-plugin-terser": "^7.0.0",
     "rollup-plugin-typescript2": "^0.27.2",
     "ts-jest": "^26.2.0",
-    "typescript": "^3.9.7"
+    "tslib": "^2.2.0",
+    "typescript": "^4.2.4"
   },
   "husky": {
     "hooks": {

--- a/packages/react-hooks/src/hooks/common/types.ts
+++ b/packages/react-hooks/src/hooks/common/types.ts
@@ -5,3 +5,7 @@ export interface CartItem {
   variant: ProductVariant;
   quantity: number;
 }
+
+export interface AnyObject {
+  [key: string]: AnyObject | string | unknown;
+}

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.provider.tsx
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.provider.tsx
@@ -1,5 +1,6 @@
 import React, { useReducer, useMemo, useContext, FC } from 'react';
-import { CartItem, AnyObject } from '../common/types';
+import { CartItem } from '../common/types';
+import { LegacyCartItem } from './use-cart.types';
 import { convertLegacyCartItem } from './utils';
 
 import {
@@ -61,7 +62,7 @@ export const CartProvider: FC<CartProviderProps> = ({
   isInCart
 }) => {
   let cart: CartItem[] = [];
-  let unformattedCart: CartItem[] | AnyObject[];
+  let unformattedCart: CartItem[] | LegacyCartItem[];
 
   const isClient = typeof window !== 'undefined';
 
@@ -80,13 +81,13 @@ export const CartProvider: FC<CartProviderProps> = ({
       unformattedCart = JSON.parse(cartString);
 
       const hasLegacyCartItems = unformattedCart?.length
-        ? (unformattedCart as AnyObject[])
-            .map((i) => Boolean(i.productId))
+        ? unformattedCart
+            .map((i: any) => Boolean(i.productId))
             .some((truthy) => truthy)
         : false;
 
       if (hasLegacyCartItems) {
-        cart = (unformattedCart as AnyObject[]).map((item) =>
+        cart = (unformattedCart as LegacyCartItem[]).map((item) =>
           convertLegacyCartItem(item)
         );
       } else {

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.provider.tsx
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.provider.tsx
@@ -82,7 +82,7 @@ export const CartProvider: FC<CartProviderProps> = ({
 
       const hasLegacyCartItems = unformattedCart?.length
         ? unformattedCart
-            .map((i: any) => Boolean(i.productId))
+            .map((i: CartItem | LegacyCartItem) => 'productId' in i)
             .some((truthy) => truthy)
         : false;
 

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.types.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.types.ts
@@ -1,3 +1,7 @@
+import {
+  NacelleShopProduct,
+  CartItem as NacelleCartItem
+} from '@nacelle/types';
 import { CartItem } from '../common/types';
 import { AddToCartFunction } from './actions/addToCart';
 import { ClearCartFunction } from './actions/clearCart';
@@ -108,6 +112,8 @@ const storageTypes = {
 export type StorageTypes =
   | typeof storageTypes[keyof typeof storageTypes]
   | null;
+
+export type LegacyCartItem = NacelleShopProduct & NacelleCartItem;
 
 export type { AddToCartFunction } from './actions/addToCart';
 export type { ClearCartFunction } from './actions/clearCart';

--- a/packages/react-hooks/src/hooks/use-cart/utils/index.ts
+++ b/packages/react-hooks/src/hooks/use-cart/utils/index.ts
@@ -1,5 +1,6 @@
-import { CartItem } from '../../common/types';
+import { ProductVariant, Media } from '@nacelle/types';
 
+import { CartItem, AnyObject } from '../../common/types';
 import { IsInCartFunction, StorageTypes } from '../use-cart.types';
 
 /**
@@ -64,4 +65,40 @@ export function unsetCacheItem(storage: StorageTypes | null) {
   }
 
   return () => {};
+}
+
+export function convertLegacyCartItem(legacyItem: AnyObject): CartItem {
+  const {
+    quantity,
+    productId,
+    handle,
+    image,
+    locale,
+    pimSyncSourceDomain,
+    pimSyncSourceProductId,
+    globalHandle,
+    availableForSale,
+    variants
+  } = legacyItem;
+
+  return {
+    quantity: Number.isInteger(quantity) ? (quantity as number) : 1,
+    product: {
+      id: productId as string,
+      featuredMedia: image as Media,
+      media: [image as Media],
+      handle: handle as string,
+      locale: locale as string,
+      globalHandle: globalHandle as string,
+      pimSyncSourceProductId: pimSyncSourceProductId as string,
+      pimSyncSourceDomain: pimSyncSourceDomain as string,
+      availableForSale:
+        typeof availableForSale === 'boolean' ? availableForSale : true,
+      indexedAt: 0,
+      variants: variants as ProductVariant[]
+    },
+    variant: {
+      ...(legacyItem.variant as ProductVariant)
+    }
+  };
 }

--- a/packages/react-hooks/src/hooks/use-cart/utils/index.ts
+++ b/packages/react-hooks/src/hooks/use-cart/utils/index.ts
@@ -1,7 +1,9 @@
-import { ProductVariant, Media } from '@nacelle/types';
-
-import { CartItem, AnyObject } from '../../common/types';
-import { IsInCartFunction, StorageTypes } from '../use-cart.types';
+import { CartItem } from '../../common/types';
+import {
+  IsInCartFunction,
+  LegacyCartItem,
+  StorageTypes
+} from '../use-cart.types';
 
 /**
  * A utility function which will return true if the item is already in the cart
@@ -67,38 +69,83 @@ export function unsetCacheItem(storage: StorageTypes | null) {
   return () => {};
 }
 
-export function convertLegacyCartItem(legacyItem: AnyObject): CartItem {
+export function convertLegacyCartItem(legacyItem: LegacyCartItem): CartItem {
   const {
     quantity,
     productId,
-    handle,
     image,
-    locale,
-    pimSyncSourceDomain,
-    pimSyncSourceProductId,
-    globalHandle,
     availableForSale,
-    variants
+    createdAt,
+    description,
+    featuredMedia,
+    globalHandle,
+    handle,
+    indexedAt,
+    locale,
+    media,
+    metafields,
+    pimSyncSource,
+    pimSyncSourceDomain,
+    pimSyncSourceLocale,
+    pimSyncSourceProductId,
+    priceRange,
+    productType,
+    tags,
+    title,
+    updatedAt,
+    variants,
+    vendor,
+    compareAtPrice,
+    compareAtPriceCurrency,
+    id,
+    price,
+    priceCurrency,
+    selectedOptions,
+    sku,
+    swatchSrc,
+    weight,
+    weightUnit
   } = legacyItem;
 
   return {
     quantity: Number.isInteger(quantity) ? (quantity as number) : 1,
     product: {
-      id: productId as string,
-      featuredMedia: image as Media,
-      media: [image as Media],
-      handle: handle as string,
-      locale: locale as string,
-      globalHandle: globalHandle as string,
-      pimSyncSourceProductId: pimSyncSourceProductId as string,
-      pimSyncSourceDomain: pimSyncSourceDomain as string,
-      availableForSale:
-        typeof availableForSale === 'boolean' ? availableForSale : true,
-      indexedAt: 0,
-      variants: variants as ProductVariant[]
+      availableForSale,
+      createdAt,
+      description,
+      featuredMedia,
+      globalHandle,
+      handle,
+      id: productId,
+      indexedAt,
+      locale,
+      media,
+      metafields,
+      pimSyncSource,
+      pimSyncSourceDomain,
+      pimSyncSourceLocale,
+      pimSyncSourceProductId,
+      priceRange,
+      productType,
+      tags,
+      title,
+      updatedAt,
+      variants,
+      vendor
     },
     variant: {
-      ...(legacyItem.variant as ProductVariant)
+      ...legacyItem.variant,
+      compareAtPrice,
+      compareAtPriceCurrency,
+      featuredMedia: image,
+      id,
+      price,
+      priceCurrency,
+      selectedOptions,
+      sku,
+      swatchSrc,
+      weight,
+      weightUnit
     }
   };
 }

--- a/packages/react-hooks/src/hooks/use-checkout/use-checkout.types.ts
+++ b/packages/react-hooks/src/hooks/use-checkout/use-checkout.types.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Checkout } from '@nacelle/types';
 import { MetafieldInput } from '@nacelle/types';
-import { CartItem } from '../common/types';
+import { CartItem, AnyObject } from '../common/types';
 
 /**
  * @param nacelleSpaceId: the target Nacelle Space ID (string)
@@ -12,10 +12,6 @@ export interface Credentials {
   nacelleSpaceId: string;
   nacelleGraphqlToken: string;
   nacelleEndpoint: string;
-}
-
-export interface AnyObject {
-  [key: string]: AnyObject | string | unknown;
 }
 
 export interface GraphQLRequestParams {


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

**Story:** [DD-442](https://nacelle.atlassian.net/browse/DD-442)

> As a merchant developer, I want @nacelle/react-hooks to remain compatible with my customer's old cart persisted in local storage, so that I don't need to delete their persisted cart

### Type of Change

- [x] Non-breaking feature

### What is being changed and why?

For customers who have a cart containing `CartItem`s in the format used in `@nacelle/react-hooks` versions `1.x`, `2.x`, and `3.x` persisted in local storage, the old `CartItem`s are mapped to the new-style (`4.0.0` and above) `CartItem` format

<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, gifs, etc are appreciated
-->

### How to Test

<!--
  If applicable, please provide a way to test the changes in a step-by-step manner
-->

From the monorepo root,
- `npm run bootstrap && cd packages/react-hooks && npm run build`
- navigate to either `examples/gatsby` or `examples/nextjs` and `npm run dev`
- with an example project running, open the developer tools and clear out any existing `cart` entry in local storage, then refresh
-  in the browser console, paste the following into the browser console, which is a stringified `cart` [generated by `@nacelle/react-hooks@2.11.6`](https://codesandbox.io/s/delicate-frost-zxcsy):

```js
window.localStorage.setItem('cart', "[{\"id\":\"Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zMzg5NDEzMjQ4MjE4Mw==\",\"title\":\"Otto Shirt\",\"price\":\"115.0\",\"priceCurrency\":\"USD\",\"compareAtPrice\":null,\"compareAtPriceCurrency\":null,\"swatchSrc\":null,\"selectedOptions\":[{\"name\":\"Title\",\"value\":\"Default Title\"}],\"sku\":null,\"availableForSale\":true,\"quantityAvailable\":null,\"metafields\":[{\"id\":null,\"namespace\":\"global\",\"key\":\"seo-url\",\"value\":\"/a/very/long/path/to/another-name-for-the-otto-shirt\"},{\"id\":null,\"namespace\":\"nacelle\",\"key\":\"vibe\",\"value\":\"Casual\"}],\"weight\":null,\"weightUnit\":null,\"priceRules\":null,\"vendor\":\"Prairie Wind Apparel\",\"tags\":[\"men\"],\"handle\":\"otto-shirt\",\"productId\":\"pepper-wood-apparel.myshopify.com::otto-shirt::en-us\",\"image\":{\"id\":\"Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYyODQ5MjQwNTE1OTE=\",\"thumbnailSrc\":\"https://cdn.shopify.com/s/files/1/0344/4362/4583/products/pexels-photo-2853527.jpg?v=1587622929&width=100\",\"src\":\"https://cdn.shopify.com/s/files/1/0344/4362/4583/products/pexels-photo-2853527.jpg?v=1587622929\",\"type\":\"image\",\"altText\":\"Otto Shirt\"},\"locale\":\"en-us\",\"quantity\":1}]")
```
- refresh the browser

If the `otto-shirt` from the local storage cart appears in the cart, then it's working as expected :)

#### Demonstration

https://user-images.githubusercontent.com/5732000/118054867-14f31880-b355-11eb-9d66-df6a12398275.mov
