### PR TITLE
[packages/react-hooks] Make `updateItem(item)` only update the target `item`

### DIFF
--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -184,7 +184,7 @@ An array containing:
     - `'closed'` - if `cartState.show` was `false`, it will remain `false`; if `cartState.show` was `true`, it will change to `false`
 - `clearCart()` - removes all items from the cart
 
-3. `isInCart` - a helper function that determines if a line item is in the cart, via `isInCart(cart, item)`. If a custom `isInCart` function is given to the `<CartProvider />` via the `isInCart` prop, the custom function will be returned instead of the default `isInCart` function.
+3. `isInCart` - a helper function that determines if a line item is in the cart, via `isInCart(cart, item)`. If a custom `isSameItem` function is given to the `<CartProvider />` via the `isSameItem` prop, the custom function will be used by the `isInCart` function.
 
 ##### Example Usage
 

--- a/packages/react-hooks/src/hooks/use-cart/actions/updateItem.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/updateItem.ts
@@ -1,17 +1,27 @@
 import { CartItem } from '../../common/types';
 
-import { isItemInCart, setCacheItem } from '~/hooks/use-cart/utils';
+import {
+  setCacheItem,
+  isItemInCart,
+  isSameItem as isSameItemDefault
+} from '~/hooks/use-cart/utils';
 import { CartState, UpdateItemAction } from '~/hooks/use-cart/use-cart.types';
 
 const updateItem: UpdateItemFunction = (
   state: CartState,
   action: UpdateItemAction
 ) => {
-  const cart: CartItem[] = state.cart.map((item) => {
-    const isInCart = action.isInCart || isItemInCart;
-    let localItem: any = null;
+  const isInCart = action.isInCart || isItemInCart;
 
-    if (isInCart(state.cart, action.payload)) {
+  if (!isInCart(state.cart, action.payload)) {
+    return state;
+  }
+
+  const cart: CartItem[] = state.cart.map((item) => {
+    let localItem: any = null;
+    const isSameItem = action.isSameItem || isSameItemDefault;
+
+    if (isSameItem(item, action.payload)) {
       localItem = { ...item };
       Object.keys(item).forEach((key) => {
         const value = (action.payload as any)[key];

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.provider.tsx
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.provider.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useMemo, useContext, FC } from 'react';
+import React, { useReducer, useMemo, useContext, FC, useCallback } from 'react';
 import { CartItem } from '../common/types';
 import { convertLegacyCartItem, isItemInCart } from './utils';
 
@@ -11,6 +11,7 @@ import {
   DecrementItemFunction,
   IncrementItemFunction,
   IsInCartFunction,
+  IsSameItemFunction,
   LegacyCartItem,
   RemoveFromCartFunction,
   StorageTypes,
@@ -42,7 +43,7 @@ export type CartProviderProps = {
   removeFromCart?: RemoveFromCartFunction;
   toggleCart?: ToggleCartFunction;
   updateItem?: UpdateItemFunction;
-  isInCart?: IsInCartFunction;
+  isSameItem?: IsSameItemFunction;
 };
 
 const CartContext = React.createContext<CartContextValue>(null);
@@ -60,7 +61,7 @@ export const CartProvider: FC<CartProviderProps> = ({
   removeFromCart,
   toggleCart,
   updateItem,
-  isInCart
+  isSameItem
 }) => {
   let cart: CartItem[] = [];
   let unformattedCart: CartItem[] | LegacyCartItem[];
@@ -101,6 +102,13 @@ export const CartProvider: FC<CartProviderProps> = ({
     ...initialState,
     cart
   });
+
+  const isInCart: IsInCartFunction = useCallback(
+    (cart: CartItem[], item: CartItem): boolean => {
+      return isItemInCart(cart, item, isSameItem);
+    },
+    [isSameItem]
+  );
 
   const cartActions: CartActions = useMemo(
     () => ({
@@ -175,7 +183,7 @@ export const CartProvider: FC<CartProviderProps> = ({
   return (
     <CartContext.Provider value={state}>
       <CartActionContext.Provider value={cartActions}>
-        <IsInCartContext.Provider value={isInCart || isItemInCart}>
+        <IsInCartContext.Provider value={isItemInCart}>
           {children}
         </IsInCartContext.Provider>
       </CartActionContext.Provider>

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.provider.tsx
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.provider.tsx
@@ -183,7 +183,7 @@ export const CartProvider: FC<CartProviderProps> = ({
   return (
     <CartContext.Provider value={state}>
       <CartActionContext.Provider value={cartActions}>
-        <IsInCartContext.Provider value={isItemInCart}>
+        <IsInCartContext.Provider value={isInCart}>
           {children}
         </IsInCartContext.Provider>
       </CartActionContext.Provider>

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.test.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.test.ts
@@ -100,9 +100,9 @@ describe('useCart reducer', () => {
           cacheKey: 'cart'
         }
       );
-      expect(
-        JSON.parse(window.localStorage.getItem('cart') as string)
-      ).toEqual([cartItem]);
+      expect(JSON.parse(window.localStorage.getItem('cart') as string)).toEqual(
+        [cartItem]
+      );
     });
 
     it('should add to item sessionStorage cart', () => {
@@ -181,6 +181,36 @@ describe('useCart reducer', () => {
       ]);
     });
 
+    it('should update only the values of the target item in the cart', () => {
+      const cartState = {
+        ...initialState,
+        cart: [cartItem, { ...cartItem, variant: { id: '2' } }]
+      };
+
+      const result = cartReducer(cartState, {
+        type: UPDATE_ITEM,
+        payload: {
+          ...cartItem,
+          quantity: 10,
+          product: {
+            ...cartItem.product,
+            title: 'Updated Title'
+          }
+        },
+        storage: null,
+        cacheKey: 'cart'
+      });
+
+      expect(result.cart).toEqual([
+        {
+          ...cartItem,
+          quantity: 10,
+          product: { ...cartItem.product, title: 'Updated Title' }
+        },
+        { ...cartItem, variant: { id: '2' } }
+      ]);
+    });
+
     it('should update some values of an item in localStorage cart', () => {
       const cartState = {
         ...initialState,
@@ -207,6 +237,37 @@ describe('useCart reducer', () => {
             quantity: 10,
             product: { ...cartItem.product, title: 'Updated Title' }
           }
+        ]
+      );
+    });
+
+    it('should update only the values of the target item in localStorage cart', () => {
+      const cartState = {
+        ...initialState,
+        cart: [cartItem, { ...cartItem, variant: { id: '2' } }]
+      };
+      cartReducer(cartState, {
+        type: UPDATE_ITEM,
+        payload: {
+          ...cartItem,
+          product: {
+            ...cartItem.product,
+            title: 'Updated Title'
+          },
+          quantity: 10
+        },
+        storage: 'local',
+        cacheKey: 'cart'
+      });
+
+      expect(JSON.parse(window.localStorage.getItem('cart') as string)).toEqual(
+        [
+          {
+            ...cartItem,
+            quantity: 10,
+            product: { ...cartItem.product, title: 'Updated Title' }
+          },
+          { ...cartItem, variant: { id: '2' } }
         ]
       );
     });
@@ -328,9 +389,9 @@ describe('useCart reducer', () => {
         cacheKey: 'cart'
       });
 
-      expect(
-        JSON.parse(window.localStorage.getItem('cart') as string)
-      ).toEqual([{ ...cartItem, quantity: 2 }]);
+      expect(JSON.parse(window.localStorage.getItem('cart') as string)).toEqual(
+        [{ ...cartItem, quantity: 2 }]
+      );
     });
 
     it('should increment the quantity of an item in sessionStorage cart', () => {
@@ -398,9 +459,9 @@ describe('useCart reducer', () => {
         cacheKey: 'cart'
       });
 
-      expect(
-        JSON.parse(window.localStorage.getItem('cart') as string)
-      ).toEqual([{ ...cartItem, quantity: 1 }]);
+      expect(JSON.parse(window.localStorage.getItem('cart') as string)).toEqual(
+        [{ ...cartItem, quantity: 1 }]
+      );
     });
 
     it('should decrement the quantity of an item in sessionStorage cart', () => {

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.types.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.types.ts
@@ -16,7 +16,12 @@ export type CartState = {
   show: boolean;
 };
 
-export type IsInCartFunction = (cart: CartItem[], payload: CartItem) => boolean;
+export type IsSameItemFunction = (itemA: CartItem, itemB?: CartItem) => boolean;
+export type IsInCartFunction = (
+  cart: CartItem[],
+  payload: CartItem,
+  itemCompareFunction?: IsSameItemFunction
+) => boolean;
 
 export interface BuildCartParams {
   cart: CartItem[];
@@ -50,6 +55,7 @@ export type UpdateItemAction = {
   cacheKey: string;
   updateItem?: UpdateItemFunction;
   isInCart?: IsInCartFunction;
+  isSameItem?: IsSameItemFunction;
 };
 
 export type IncrementItemAction = {
@@ -106,7 +112,8 @@ const cartToggleStates = {
   closed: 'closed'
 } as const;
 
-export type CartToggleStates = typeof cartToggleStates[keyof typeof cartToggleStates];
+export type CartToggleStates =
+  typeof cartToggleStates[keyof typeof cartToggleStates];
 
 const storageTypes = {
   session: 'session',

--- a/packages/react-hooks/src/hooks/use-cart/utils/index.ts
+++ b/packages/react-hooks/src/hooks/use-cart/utils/index.ts
@@ -1,5 +1,21 @@
 import { CartItem } from '../../common/types';
-import { LegacyCartItem, StorageTypes } from '../use-cart.types';
+import {
+  IsSameItemFunction,
+  LegacyCartItem,
+  StorageTypes
+} from '../use-cart.types';
+
+/**
+ * A utility method which will return true if the the two provided items are
+ * the same item
+ * @param itemA a CartItem
+ * @param itemB a CartItem
+ *
+ * @returns a boolean indicating if the two items are the same
+ */
+export function isSameItem(itemA: CartItem, itemB?: CartItem): boolean {
+  return itemA.variant.id === itemB?.variant?.id;
+}
 
 /**
  * A utility function which will return true if the item is already in the cart
@@ -9,8 +25,13 @@ import { LegacyCartItem, StorageTypes } from '../use-cart.types';
  *
  * @returns a boolean indiciating if the item is already in the cart
  */
-export function isItemInCart(cart: CartItem[], payload: CartItem): boolean {
-  return cart.findIndex((item) => item.variant.id === payload.variant?.id) > -1;
+export function isItemInCart(
+  cart: CartItem[],
+  payload: CartItem,
+  itemCompareFunction?: IsSameItemFunction
+): boolean {
+  const compare = itemCompareFunction || isSameItem;
+  return cart.findIndex((item) => compare(item, payload)) > -1;
 }
 
 export function setCacheItem(storage: StorageTypes | null) {


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

**Story:** [NS-883](https://nacelle.atlassian.net/servicedesk/customer/portal/7/NS-883) <!-- link to Jira story -->


### Type of Change

- [x] Bug fix
- [ ] Non-breaking feature
- [ ] Breaking feature
- [ ] Chore (docs, refactor, etc)

### What is being changed and why?
The `updateItem` method currently updates every item in the cart with the properties on the `item` param if `item` is in the cart:
```jsx
const updateItem: UpdateItemFunction = (
  state: CartState,
  action: UpdateItemAction
) => {
  const cart: CartItem[] = state.cart.map((item) => {
    const isInCart = action.isInCart || isItemInCart;
    let localItem: any = null;
```
It maps over the whole cart by default, but, for each item, it checks if the provided `item` is in the cart - if this is true once it will be true on every iteration.
```
    if (isInCart(state.cart, action.payload)) {
```
Which means the properties on every item in the cart get changed.
```
      localItem = { ...item };
      Object.keys(item).forEach((key) => {
        const value = (action.payload as any)[key];

        if (value && key !== 'id' && localItem[key] !== value) {
          localItem[key] = value;
        }
      });
    }

    return localItem || item;
  });

  setCacheItem(action.storage)(action.cacheKey || 'cart', JSON.stringify(cart));

  return {
    ...state,
    cart
  };
};
```

The fact that `isInCart` is configurable made this a little more complicated than I thought it would be. The least invasive change I could think of was to make the comparison function (which I added) `isSameItem` configurable and making `isInCart` use the comparison function if provided by the consuming code. Unfortunately, this means the API has to change - you can no longer provide `isInCart`, only `isSameItem`.

<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, gifs, etc are appreciated
-->

### How to Test

I added two tests that fail on the current `main` branch. The existing tests for `updateItem` only test against one item in the cart. I can also provide a deploy with an example if that would be helpful.

<!--
  If applicable, please provide a way to test the changes in a step-by-step manner
-->
