### PR TITLE
[packages/react-hooks] Fix Bug in `updateItem` Action

### DIFF
--- a/packages/react-hooks/src/hooks/use-cart/actions/updateItem.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/updateItem.ts
@@ -11,7 +11,7 @@ const updateItem: UpdateItemFunction = (
     const isInCart = action.isInCart || isItemInCart;
     let localItem: any = null;
 
-    if (isInCart(state.cart, action.payload)) {
+    if (isInCart([item], action.payload)) {
       localItem = { ...item };
       Object.keys(item).forEach((key) => {
         const value = (action.payload as any)[key];

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.test.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.test.ts
@@ -100,9 +100,9 @@ describe('useCart reducer', () => {
           cacheKey: 'cart'
         }
       );
-      expect(
-        JSON.parse(window.localStorage.getItem('cart') as string)
-      ).toEqual([cartItem]);
+      expect(JSON.parse(window.localStorage.getItem('cart') as string)).toEqual(
+        [cartItem]
+      );
     });
 
     it('should add to item sessionStorage cart', () => {
@@ -179,6 +179,41 @@ describe('useCart reducer', () => {
           product: { ...cartItem.product, title: 'Updated Title' }
         }
       ]);
+    });
+
+    it('should only update the values of a matching cart item, and not other cart items', () => {
+      const secondCartItem = {
+        product: {
+          ...cartItem.product,
+          title: 'Another Product'
+        },
+        variant: { id: '6789' },
+        quantity: 2
+      };
+      const cartState = {
+        ...initialState,
+        cart: [cartItem, secondCartItem]
+      };
+
+      const result = cartReducer(cartState, {
+        type: UPDATE_ITEM,
+        payload: {
+          ...cartItem,
+          quantity: 10,
+          product: {
+            ...cartItem.product,
+            title: 'Updated Title'
+          }
+        },
+        storage: null,
+        cacheKey: 'cart'
+      });
+
+      expect(result.cart[0].quantity).toEqual(10);
+      expect(result.cart[1].quantity).toEqual(2);
+
+      expect(result.cart[0].product.title).toEqual('Updated Title');
+      expect(result.cart[1].product.title).toEqual('Another Product');
     });
 
     it('should update some values of an item in localStorage cart', () => {
@@ -328,9 +363,9 @@ describe('useCart reducer', () => {
         cacheKey: 'cart'
       });
 
-      expect(
-        JSON.parse(window.localStorage.getItem('cart') as string)
-      ).toEqual([{ ...cartItem, quantity: 2 }]);
+      expect(JSON.parse(window.localStorage.getItem('cart') as string)).toEqual(
+        [{ ...cartItem, quantity: 2 }]
+      );
     });
 
     it('should increment the quantity of an item in sessionStorage cart', () => {
@@ -398,9 +433,9 @@ describe('useCart reducer', () => {
         cacheKey: 'cart'
       });
 
-      expect(
-        JSON.parse(window.localStorage.getItem('cart') as string)
-      ).toEqual([{ ...cartItem, quantity: 1 }]);
+      expect(JSON.parse(window.localStorage.getItem('cart') as string)).toEqual(
+        [{ ...cartItem, quantity: 1 }]
+      );
     });
 
     it('should decrement the quantity of an item in sessionStorage cart', () => {

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.test.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.test.ts
@@ -246,6 +246,43 @@ describe('useCart reducer', () => {
       );
     });
 
+    it('should only update the values of a matching cart item, and not other cart items, in the localStorage cart', () => {
+      const secondCartItem = {
+        product: {
+          ...cartItem.product,
+          title: 'Another Product'
+        },
+        variant: { id: '6789' },
+        quantity: 2
+      };
+      const cartState = {
+        ...initialState,
+        cart: [cartItem, secondCartItem]
+      };
+
+      cartReducer(cartState, {
+        type: UPDATE_ITEM,
+        payload: {
+          ...cartItem,
+          quantity: 10,
+          product: {
+            ...cartItem.product,
+            title: 'Updated Title'
+          }
+        },
+        storage: 'local',
+        cacheKey: 'cart'
+      });
+
+      const cart = JSON.parse(window.localStorage.getItem('cart') as string);
+
+      expect(cart[0].quantity).toEqual(10);
+      expect(cart[1].quantity).toEqual(2);
+
+      expect(cart[0].product.title).toEqual('Updated Title');
+      expect(cart[1].product.title).toEqual('Another Product');
+    });
+
     it('should update some values of an item in sessionStorage cart', () => {
       const cartState = {
         ...initialState,


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

### Story

[DD-756](https://nacelle.atlassian.net/browse/DD-756)

> @nacelle/react-hooks `cartActions.updateItem(item)` updates every item in the cart with properties of the `item` param

### Type of Change

- [x] Bug fix

### What is being changed and why?

#53 identified an issue with the `updateItem` action, in which `updateItem` would erroneously run on every item in the cart, instead of on the item of interest. This PR adds unit tests to check that this doesn't happen, and adds a small change to the `updateItem` action to fix the issue, without any API changes.

<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, gifs, etc are appreciated
-->

### Demonstration

https://user-images.githubusercontent.com/5732000/122834168-17ce1b00-d2bc-11eb-84fa-51219059bdd2.mov

### How to Test

<!--
  If applicable, please provide a way to test the changes in a step-by-step manner
-->

- CI for this PR should pass
- Unit tests should pass
  - Pull the `DD-756-updateItem-bugfix` branch
  - `npm run bootstrap` from monorepo root
  - `cd packages/react-hooks && npm run test`

### Next Steps

- Publish [`@nacelle/react-hooks`](https://www.npmjs.com/package/@nacelle/react-hooks)`@5.1.4.`
- Close #53
