### PR TITLE
[examples/nextjs] Use Consistent `previewData` in Next.js Preview Utils

### DIFF
--- a/examples/nextjs/pages/[blogHandle]/[handle].js
+++ b/examples/nextjs/pages/[blogHandle]/[handle].js
@@ -26,12 +26,16 @@ export async function getStaticPaths() {
   }
 }
 
-export async function getStaticProps({ params: { handle, blogHandle } }) {
+export async function getStaticProps({
+  params: { handle, blogHandle },
+  previewData
+}) {
   try {
     const articles = await nacelleClient.data
       .article({
         handle,
-        blogHandle
+        blogHandle,
+        previewData
       })
       .catch(() => {
         console.warn(

--- a/examples/nextjs/pages/api/preview.js
+++ b/examples/nextjs/pages/api/preview.js
@@ -47,19 +47,32 @@ export default async function handler(req, res) {
     } else {
       handleRedirect({ res, newPath, method, handle, locale });
     }
-  } else if (path.startsWith('/articles/')) {
-    const method = 'article';
-    const { newPath, handle } = await getPathFromData({ path, method, locale });
-
-    handleRedirect({ res, newPath, method, handle, locale });
   } else {
-    // If path doesn't match any of the blocks above, redirect to home page
-    handleRedirect({
-      res,
-      newPath: '/',
-      method: 'n/a',
-      handle: 'n/a',
-      locale: 'n/a'
-    });
+    try {
+      const method = 'article';
+
+      // blogHandle example: in `/wellness/eat-avocados`, the blogHandle is `wellness`
+      const [, blogHandle] = [...path.matchAll(/([\w|-]+)/g)]
+        .map((matches) => matches[0])
+        .reverse();
+
+      const { newPath, handle } = await getPathFromData({
+        path,
+        method,
+        blogHandle,
+        locale
+      });
+
+      handleRedirect({ res, newPath, method, handle, locale });
+    } catch (err) {
+      // If path doesn't match any of the blocks above and isn't a blog article, redirect to home page
+      handleRedirect({
+        res,
+        newPath: '/',
+        method: 'n/a',
+        handle: 'n/a',
+        locale: 'n/a'
+      });
+    }
   }
 }

--- a/examples/nextjs/utils/preview/getPathFromData.js
+++ b/examples/nextjs/utils/preview/getPathFromData.js
@@ -1,7 +1,7 @@
 import { nacelleClient } from 'services';
 import { previewData } from './handleRedirect';
 /**
- *  Redirecting to req.query.path might lead to open redirect vulnerabilities.
+ * Redirecting to req.query.path might lead to open redirect vulnerabilities.
  * Instead, we'll use the handle from the provided path to fetch data with
  * the Nacelle Client JS SDK. If a result is found, we'll redirect to the
  * path associated with the data fetched with the Nacelle Client JS SDK.
@@ -13,18 +13,29 @@ import { previewData } from './handleRedirect';
 export default async function getPathFromData({
   path,
   method,
+  blogHandle,
   locale = 'en-us'
 }) {
-  const [, pathPrefix, handle] = path.split('/');
-  const data = await nacelleClient.data[method]({
+  const [handle] = [...path.matchAll(/([\w|-]+)/g)]
+    .map((matches) => matches[0])
+    .reverse();
+  const pathPrefix = path.split(`/${handle}`).shift();
+  const params = {
     handle,
     locale,
     previewData
-  }).catch((err) => {
+  };
+
+  if (blogHandle && method === 'article') {
+    params.blogHandle = blogHandle;
+  }
+
+  const data = await nacelleClient.data[method](params).catch((err) => {
     console.warn(err);
     return null;
   });
-  const newPath = data?.handle ? `/${pathPrefix}/${data.handle}` : null;
+
+  const newPath = data?.handle ? `${pathPrefix}/${data.handle}` : null;
 
   return { newPath, handle };
 }

--- a/examples/nextjs/utils/preview/getPathFromData.js
+++ b/examples/nextjs/utils/preview/getPathFromData.js
@@ -1,4 +1,5 @@
 import { nacelleClient } from 'services';
+import { previewData } from './handleRedirect';
 /**
  *  Redirecting to req.query.path might lead to open redirect vulnerabilities.
  * Instead, we'll use the handle from the provided path to fetch data with
@@ -18,7 +19,7 @@ export default async function getPathFromData({
   const data = await nacelleClient.data[method]({
     handle,
     locale,
-    preview: true
+    previewData
   }).catch((err) => {
     console.warn(err);
     return null;

--- a/examples/nextjs/utils/preview/handleRedirect.js
+++ b/examples/nextjs/utils/preview/handleRedirect.js
@@ -1,3 +1,5 @@
+export const previewData = {};
+
 /**
  * Handle redirect to newPath, or provide error message specific to
  * the path, handle, and method being used to fetch the newPath.
@@ -18,7 +20,7 @@ export default function handleRedirect({
   // Redirect to the path from the fetched data
   if (newPath) {
     // Set cookies to enable Preview Mode
-    res.setPreviewData({});
+    res.setPreviewData(previewData);
     console.info('[nacelle] preview mode enabled');
     res.redirect(newPath);
   } else {

--- a/examples/nextjs/utils/preview/handleRedirect.js
+++ b/examples/nextjs/utils/preview/handleRedirect.js
@@ -19,7 +19,7 @@ export default function handleRedirect({
 }) {
   // Redirect to the path from the fetched data
   if (newPath) {
-    // Set cookies to enable Preview Mode
+    // Set cookies to enable Preview Mode and redirect to secure path
     res.setPreviewData(previewData);
     console.info('[nacelle] preview mode enabled');
     res.redirect(newPath);


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

### Story

[DD-772](https://nacelle.atlassian.net/browse/DD-772)

> Fix previewData bug in getPathFromData preview util function

### Type of Change

- [x] Bug fix

### What is being changed and why?

<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, gifs, etc are appreciated
-->

This PR fixes a couple of oversights from #55:
-  the `examples/nextjs/utils/preview/getPathFromData.js` utility function was using the old `preview: true` instead of passing the `previewData` that the `nacelleClient` needs in order to fetch preview data
- article routes weren't handled correctly in `/api/preview`, and weren't passing `previewData` to the `nacelleClient` in the article page template

With this PR, `previewData` is used as a named export `examples/nextjs/utils/preview/getPathFromData.js`, which means that the merchant developer only needs to use Shopify / Contentful / Sanity-specific environment variables in one place. This makes it easier to configure projects as per the Next.js x (Sanity, Contentful) Preview Mode recipes.

### How to Test

Either follow the recipe instructions outlined in:
- https://deploy-preview-173--nacelle-public-docs.netlify.app/next/recipes/preview/preview-shopify-contentful.html, or
- https://deploy-preview-173--nacelle-public-docs.netlify.app/next/recipes/preview/preview-shopify-sanity.html

, or alternatively, visit a deploy preview of the `DD-733-demo-contentful-shopify` branch, which is based on the `DD-733-update-next-js-preview-mode` branch, but follows the Preview Mode recipe described in https://deploy-preview-173--nacelle-public-docs.netlify.app/next/recipes/preview/preview-shopify-contentful.html, and test draft content changes.

#### Deploy Previews that Follow the Recipe for Shopify + Contentful Previews
- [for Prairie Wind Apparel](https://nacelle-nextjs-example-git-dd-733-demo-contentfu-3f6a57-nacelle.vercel.app)
- [for Gamma Nova Jewelry](https://gamma-nova-jewelry-git-dd-733-demo-contentful-shopify-nacelle.vercel.app)

