### PR TITLE
updateItem accept falsy values

### DIFF
--- a/packages/react-hooks/src/hooks/use-cart/actions/updateItem.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/updateItem.ts
@@ -16,7 +16,7 @@ const updateItem: UpdateItemFunction = (
       Object.keys(item).forEach((key) => {
         const value = (action.payload as any)[key];
 
-        if (value && key !== 'id' && localItem[key] !== value) {
+        if (key !== 'id' && localItem[key] !== value) {
           localItem[key] = value;
         }
       });

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.test.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.test.ts
@@ -100,9 +100,9 @@ describe('useCart reducer', () => {
           cacheKey: 'cart'
         }
       );
-      expect(JSON.parse(window.localStorage.getItem('cart') as string)).toEqual(
-        [cartItem]
-      );
+      expect(
+        JSON.parse(window.localStorage.getItem('cart') as string)
+      ).toEqual([cartItem]);
     });
 
     it('should add to item sessionStorage cart', () => {
@@ -312,6 +312,35 @@ describe('useCart reducer', () => {
         }
       ]);
     });
+
+    it('should update to a falsy value of an item in the cart', () => {
+      const cartState = {
+        ...initialState,
+        cart: [cartItem]
+      };
+
+      const result = cartReducer(cartState, {
+        type: UPDATE_ITEM,
+        payload: {
+          ...cartItem,
+          quantity: 10,
+          product: {
+            ...cartItem.product,
+            title: ''
+          }
+        },
+        storage: null,
+        cacheKey: 'cart'
+      });
+
+      expect(result.cart).toEqual([
+        {
+          ...cartItem,
+          quantity: 10,
+          product: { ...cartItem.product, title: '' }
+        }
+      ]);
+    });
   });
 
   describe(`${REMOVE_FROM_CART}`, () => {
@@ -400,9 +429,9 @@ describe('useCart reducer', () => {
         cacheKey: 'cart'
       });
 
-      expect(JSON.parse(window.localStorage.getItem('cart') as string)).toEqual(
-        [{ ...cartItem, quantity: 2 }]
-      );
+      expect(
+        JSON.parse(window.localStorage.getItem('cart') as string)
+      ).toEqual([{ ...cartItem, quantity: 2 }]);
     });
 
     it('should increment the quantity of an item in sessionStorage cart', () => {
@@ -470,9 +499,9 @@ describe('useCart reducer', () => {
         cacheKey: 'cart'
       });
 
-      expect(JSON.parse(window.localStorage.getItem('cart') as string)).toEqual(
-        [{ ...cartItem, quantity: 1 }]
-      );
+      expect(
+        JSON.parse(window.localStorage.getItem('cart') as string)
+      ).toEqual([{ ...cartItem, quantity: 1 }]);
     });
 
     it('should decrement the quantity of an item in sessionStorage cart', () => {


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

**Story:** [DD-773](https://nacelle.atlassian.net/browse/DD-773) <!-- link to Jira story -->

### Type of Change

- [ ] Bug fix
- [ x] Non-breaking feature
- [ ] Breaking feature
- [ ] Chore (docs, refactor, etc)

### What is being changed and why?

Merchant requested the ability to add falsy values to lineItem property with the updateItem function

<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, gifs, etc are appreciated
-->

### How to Test

`npm run test`

<!--
  If applicable, please provide a way to test the changes in a step-by-step manner
-->
