### PR TITLE
[packages/react-hooks|DD-819] Add discount query param for Shopify checkouts

### DIFF
--- a/packages/react-hooks/src/hooks/use-checkout/async-handlers/processCheckout.ts
+++ b/packages/react-hooks/src/hooks/use-checkout/async-handlers/processCheckout.ts
@@ -9,88 +9,94 @@ import {
   ProcessCheckoutAction
 } from 'hooks/use-checkout/use-checkout.types';
 
-const processCheckout: ActionHandler = ({ dispatch }) => async (
-  action: ProcessCheckoutAction
-): Promise<void> => {
-  if (typeof window !== 'undefined') {
-    const {
-      lineItems,
-      checkoutId,
-      metafields,
-      note,
-      discountCodes,
-      source
-    } = action.payload;
+const processCheckout: ActionHandler =
+  ({ dispatch }) =>
+  async (action: ProcessCheckoutAction): Promise<void> => {
+    if (typeof window !== 'undefined') {
+      const { lineItems, checkoutId, metafields, note, discountCodes, source } =
+        action.payload;
+      let checkoutUrl = '';
 
-    const cartItems = lineItems.map((item, idx) => ({
-      variantId: item.variant.id,
-      cartItemId: `${idx}::${item.variant.id}`,
-      quantity: item.quantity,
-      metafields: [
-        ...(item.product.metafields || []),
-        ...(item.variant.metafields || [])
-      ].map((m) => ({ key: m.key, value: m.value }))
-    }));
+      const cartItems = lineItems.map((item, idx) => ({
+        variantId: item.variant.id,
+        cartItemId: `${idx}::${item.variant.id}`,
+        quantity: item.quantity,
+        metafields: [
+          ...(item.product.metafields || []),
+          ...(item.variant.metafields || [])
+        ].map((m) => ({ key: m.key, value: m.value }))
+      }));
 
-    if (action.isCheckingOut) {
-      // while processing checkout, don't process checkout again
-      return;
-    }
+      if (action.isCheckingOut) {
+        // while processing checkout, don't process checkout again
+        return;
+      }
 
-    action.setIsCheckingOut(true);
+      action.setIsCheckingOut(true);
 
-    const id = checkoutId || window.localStorage.getItem('checkoutId');
+      const id = checkoutId || window.localStorage.getItem('checkoutId');
 
-    const input: NacelleCheckoutInput = {
-      cartItems,
-      checkoutId: id,
-      metafields,
-      note,
-      discountCodes,
-      source
-    };
-
-    const response = await hailFrequencyRequest({
-      credentials: action.credentials,
-      query: PROCESS_CHECKOUT_QUERY,
-      variables: { input }
-    });
-
-    const checkoutResult: ProcessCheckoutResponse = await response.json();
-
-    if (checkoutResult.errors) {
-      throw new Error(
-        `Checkout Errors:\n${JSON.stringify(checkoutResult.errors, null, 2)}`
-      );
-    }
-
-    if (checkoutResult.data?.processCheckout) {
-      const {
-        id,
-        completed,
-        url,
+      const input: NacelleCheckoutInput = {
+        cartItems,
+        checkoutId: id,
+        metafields,
+        note,
+        discountCodes,
         source
-      } = checkoutResult.data.processCheckout;
+      };
 
-      dispatch({
-        type: SET_CHECKOUT_DATA,
-        payload: {
-          checkoutId: id,
-          checkoutComplete: completed,
-          checkoutUrl: url as string,
-          checkoutSource: source as string
-        }
+      const response = await hailFrequencyRequest({
+        credentials: action.credentials,
+        query: PROCESS_CHECKOUT_QUERY,
+        variables: { input }
       });
-    }
 
-    if (action.isMounted) {
-      action.setIsCheckingOut(false);
+      const checkoutResult: ProcessCheckoutResponse = await response.json();
 
-      if (checkoutResult?.data?.processCheckout?.url) {
-        window.location.href = checkoutResult.data.processCheckout.url;
+      if (checkoutResult.errors) {
+        throw new Error(
+          `Checkout Errors:\n${JSON.stringify(checkoutResult.errors, null, 2)}`
+        );
+      }
+
+      if (checkoutResult.data?.processCheckout) {
+        const { id, completed, url, source } =
+          checkoutResult.data.processCheckout;
+
+        if (url) {
+          const parsedUrl = new URL(url);
+
+          if (source && source === 'Shopify') {
+            const discountCode =
+              Array.isArray(discountCodes) && discountCodes[0];
+
+            if (discountCode) {
+              parsedUrl.searchParams.set('discount', discountCode);
+            }
+          }
+
+          checkoutUrl = parsedUrl.toString();
+        }
+
+        dispatch({
+          type: SET_CHECKOUT_DATA,
+          payload: {
+            checkoutId: id,
+            checkoutComplete: completed,
+            checkoutUrl,
+            checkoutSource: source as string
+          }
+        });
+      }
+
+      if (action.isMounted) {
+        action.setIsCheckingOut(false);
+
+        if (checkoutUrl) {
+          window.location.href = checkoutUrl;
+        }
       }
     }
-  }
-};
+  };
 
 export default processCheckout;


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

### Story

[DD-819](https://nacelle.atlassian.net/browse/DD-819)

> For Shopify checkouts, apply discount code via checkout URL query param in @nacelle/react-hooks' processCheckout function

### Type of Change

- [x] Bug fix (bump to `5.1.7`)

### What is being changed and why?

Until full `discountCodes` support for Shopify is added to Hail Frequency, this PR bridges the gap by adding a `discount=some-discount-code` query parameter for Shopify checkouts, using `discountCodes[0]`.

### How to Test

This PR has been end-to-end tested with the Next.js example project (see demonstration below), with and without `discountCodes`.

Check out the `DD-819-shopify-checkout-discount-code` branch.

From the monorepo root:
- `npm run bootstrap`
- `cd packages/react-hooks && npm run build && npm run test:ci`
- in an example project, add a valid discount code in the `discountCodes` that are accepted by the `processCheckout` function
- perform a checkout; the discount code should be auto-applied

### Demonstration

https://user-images.githubusercontent.com/5732000/125982826-8f21e89d-c21f-4d61-ab21-d972240cb1a8.mov

### Future Work

At the moment, it's impractical to write unit tests for `packages/react-hooks/src/hooks/use-checkout/async-handlers/*.ts`.

The `packages/react-hooks/src/hooks/use-checkout/async-handlers` could be refactored such that the functions themselves are easy to write unit tests for, with the default export using a higher-order function to wrap the function as a `ActionHandler`.