### PR TITLE
LD441 - index db option for useCart

### DIFF
--- a/examples/nextjs/pages/_app.js
+++ b/examples/nextjs/pages/_app.js
@@ -17,7 +17,7 @@ const checkoutCredentials = {
 
 function MyApp({ Component, pageProps, space, products }) {
   return (
-    <CartProvider storage={'idb'}>
+    <CartProvider>
       <CheckoutProvider credentials={checkoutCredentials}>
         <Global styles={styles.global} />
         <ProductSearchProvider products={products}>

--- a/examples/nextjs/pages/_app.js
+++ b/examples/nextjs/pages/_app.js
@@ -17,7 +17,7 @@ const checkoutCredentials = {
 
 function MyApp({ Component, pageProps, space, products }) {
   return (
-    <CartProvider>
+    <CartProvider storage={'idb'}>
       <CheckoutProvider credentials={checkoutCredentials}>
         <Global styles={styles.global} />
         <ProductSearchProvider products={products}>

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -182,7 +182,7 @@ An array containing:
 
 2. `cartActions`: an object containing methods for interacting with the cart:
 
-- `initCart(items)` - initialize/override the cart with a list of cart items
+- `initCart(items)` - initialize/override the cart with an array of cart items
 - `addToCart(item)` - add an item to the cart; if the item is already in the cart this function will increase the quantity of that item
 - `updateItem(item)` - modify properties of an item in the cart
 - `removeFromCart(item)` - remove an item from the cart

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -155,7 +155,7 @@ const App = () => {
 
 ##### Cart Persistence
 
-By default, the `<CartProvider />` uses [Local Storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) to persist the cart between refreshes. If you would prefer to use [Session Storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) instead of Local Storage, pass `storage={'session'}` as a prop. To disable cart storage entirely, pass `storage={null}` as a prop.
+By default, the `<CartProvider />` uses [Local Storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) to persist the cart between refreshes. If you would prefer to use [Session Storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) instead of Local Storage, pass `storage={'session'}` as a prop. If you would prefer to use [Index DB Storage](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) instead, pass `storage={'idb'}` as a prop. To disable cart storage entirely, pass `storage={null}` as a prop.
 
 When using Local Storage or Session Storage to perist the cart, the default storage key of `'cart'` can be overriden by supplying a `cacheKey="my-custom-cart=key"` prop.
 

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -182,6 +182,7 @@ An array containing:
 
 2. `cartActions`: an object containing methods for interacting with the cart:
 
+- `initCart(items)` - initialize/override the cart with a list of cart items
 - `addToCart(item)` - add an item to the cart; if the item is already in the cart this function will increase the quantity of that item
 - `updateItem(item)` - modify properties of an item in the cart
 - `removeFromCart(item)` - remove an item from the cart

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -58,5 +58,8 @@
   "gitHead": "3153c14f529fa9f691e7cd2e6c44cee74d1a78db",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "idb-keyval": "^5.1.3"
   }
 }

--- a/packages/react-hooks/src/hooks/use-cart/actions/index.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/index.ts
@@ -6,6 +6,7 @@ export { default as addToCart } from './addToCart';
 export { default as clearCart } from './clearCart';
 export { default as decrementItem } from './decrementItem';
 export { default as incrementItem } from './incrementItem';
+export { default as initCart } from './initCart';
 export { default as removeFromCart } from './removeFromCart';
 export { default as toggleCart } from './toggleCart';
 export { default as updateItem } from './updateItem';

--- a/packages/react-hooks/src/hooks/use-cart/actions/initCart.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/initCart.ts
@@ -1,0 +1,25 @@
+import { CartItem } from '../../common/types';
+
+import { InitCartAction, CartState } from '~/hooks/use-cart/use-cart.types';
+
+const initCart: InitCartFunction = (
+  state: CartState,
+  action: InitCartAction
+) => {
+  const cart: CartItem[] = [...action.payload];
+
+  return {
+    ...state,
+    cart
+  };
+};
+
+export default initCart;
+
+export type InitCartFunction = (
+  state: CartState,
+  action: InitCartAction
+) => {
+  cart: CartItem[];
+  show: boolean;
+};

--- a/packages/react-hooks/src/hooks/use-cart/actions/initCart.ts
+++ b/packages/react-hooks/src/hooks/use-cart/actions/initCart.ts
@@ -1,5 +1,6 @@
 import { CartItem } from '../../common/types';
 
+import { setCacheItem } from '~/hooks/use-cart/utils';
 import { InitCartAction, CartState } from '~/hooks/use-cart/use-cart.types';
 
 const initCart: InitCartFunction = (
@@ -7,6 +8,8 @@ const initCart: InitCartFunction = (
   action: InitCartAction
 ) => {
   const cart: CartItem[] = [...action.payload];
+
+  setCacheItem(action.storage)(action.cacheKey || 'cart', JSON.stringify(cart));
 
   return {
     ...state,

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.provider.tsx
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.provider.tsx
@@ -101,7 +101,9 @@ export const CartProvider: FC<CartProviderProps> = ({
           if (cart) {
             dispatch({
               type: INIT_CART,
-              payload: cart
+              payload: cart,
+              storage,
+              cacheKey
             });
           }
         }
@@ -115,7 +117,9 @@ export const CartProvider: FC<CartProviderProps> = ({
       initCart: (payload: CartItem[]): void =>
         dispatch({
           type: INIT_CART,
-          payload
+          payload,
+          storage,
+          cacheKey
         }),
       addToCart: (payload: CartItem): void =>
         dispatch({

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.test.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.test.ts
@@ -5,9 +5,22 @@ const cartItem = {
   variant: shopifyItem?.variants ? shopifyItem.variants[0] : { id: '12345' },
   quantity: 1
 };
+const cartItems = [
+  {
+    product: shopifyItem,
+    variant: shopifyItem?.variants ? shopifyItem.variants[0] : { id: '12345' },
+    quantity: 1
+  },
+  {
+    product: shopifyItem,
+    variant: shopifyItem?.variants ? shopifyItem.variants[1] : { id: '23456' },
+    quantity: 1
+  }
+];
 
 import cartReducer, {
   initialState,
+  INIT_CART,
   ADD_TO_CART,
   UPDATE_ITEM,
   REMOVE_FROM_CART,
@@ -45,6 +58,16 @@ describe('useCart reducer', () => {
 
     Object.defineProperty(window, 'localStorage', {
       value: storageMock()
+    });
+  });
+
+  describe(`${INIT_CART}`, () => {
+    it('should initialize cart with payload items', () => {
+      const result = cartReducer(initialState, {
+        type: INIT_CART,
+        payload: cartItems
+      });
+      expect(result.cart).toEqual(cartItems);
     });
   });
 
@@ -100,9 +123,9 @@ describe('useCart reducer', () => {
           cacheKey: 'cart'
         }
       );
-      expect(
-        JSON.parse(window.localStorage.getItem('cart') as string)
-      ).toEqual([cartItem]);
+      expect(JSON.parse(window.localStorage.getItem('cart') as string)).toEqual(
+        [cartItem]
+      );
     });
 
     it('should add to item sessionStorage cart', () => {
@@ -429,9 +452,9 @@ describe('useCart reducer', () => {
         cacheKey: 'cart'
       });
 
-      expect(
-        JSON.parse(window.localStorage.getItem('cart') as string)
-      ).toEqual([{ ...cartItem, quantity: 2 }]);
+      expect(JSON.parse(window.localStorage.getItem('cart') as string)).toEqual(
+        [{ ...cartItem, quantity: 2 }]
+      );
     });
 
     it('should increment the quantity of an item in sessionStorage cart', () => {
@@ -499,9 +522,9 @@ describe('useCart reducer', () => {
         cacheKey: 'cart'
       });
 
-      expect(
-        JSON.parse(window.localStorage.getItem('cart') as string)
-      ).toEqual([{ ...cartItem, quantity: 1 }]);
+      expect(JSON.parse(window.localStorage.getItem('cart') as string)).toEqual(
+        [{ ...cartItem, quantity: 1 }]
+      );
     });
 
     it('should decrement the quantity of an item in sessionStorage cart', () => {

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.ts
@@ -5,6 +5,7 @@ import {
   ClearCartFunction,
   DecrementItemFunction,
   IncrementItemFunction,
+  InitCartFunction,
   RemoveFromCartFunction,
   ToggleCartFunction,
   UpdateItemFunction,
@@ -16,11 +17,13 @@ import {
   clearCart as clearCartDefault,
   decrementItem as decrementItemDefault,
   incrementItem as incrementItemDefault,
+  initCart as initCartDefault,
   removeFromCart as removeFromCartDefault,
   toggleCart as toggleCartDefault,
   updateItem as updateItemDefault
 } from './actions';
 
+export const INIT_CART = 'cart/init-cart';
 export const ADD_TO_CART = 'cart/add-to-cart';
 export const INCREMENT_ITEM = 'cart/increment-item';
 export const DECREMENT_ITEM = 'cart/decrement-item';
@@ -40,6 +43,7 @@ export interface CreateCartReducerParams {
   clearCart?: ClearCartFunction;
   decrementItem?: DecrementItemFunction;
   incrementItem?: IncrementItemFunction;
+  initCart?: InitCartFunction;
   removeFromCart?: RemoveFromCartFunction;
   toggleCart?: ToggleCartFunction;
   updateItem?: UpdateItemFunction;
@@ -51,6 +55,12 @@ const cartReducer = (
   action: CartReducerAction
 ): CartState => {
   switch (action.type) {
+    case INIT_CART: {
+      return action.initCart
+        ? action.initCart(state, action)
+        : initCartDefault(state, action);
+    }
+
     case ADD_TO_CART: {
       return action.addToCart
         ? action.addToCart(state, action)

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.types.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.types.ts
@@ -106,11 +106,13 @@ const cartToggleStates = {
   closed: 'closed'
 } as const;
 
-export type CartToggleStates = typeof cartToggleStates[keyof typeof cartToggleStates];
+export type CartToggleStates =
+  typeof cartToggleStates[keyof typeof cartToggleStates];
 
 const storageTypes = {
   session: 'session',
-  local: 'local'
+  local: 'local',
+  idb: 'idb'
 } as const;
 
 export type StorageTypes =

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.types.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.types.ts
@@ -39,6 +39,8 @@ export type CartActions = {
 export type InitCartAction = {
   type: 'cart/init-cart';
   payload: CartItem[];
+  storage: StorageTypes;
+  cacheKey: string;
   initCart?: InitCartFunction;
 };
 

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.types.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.types.ts
@@ -7,6 +7,7 @@ import { AddToCartFunction } from './actions/addToCart';
 import { ClearCartFunction } from './actions/clearCart';
 import { DecrementItemFunction } from './actions/decrementItem';
 import { IncrementItemFunction } from './actions/incrementItem';
+import { InitCartFunction } from './actions/initCart';
 import { RemoveFromCartFunction } from './actions/removeFromCart';
 import { ToggleCartFunction } from './actions/toggleCart';
 import { UpdateItemFunction } from './actions/updateItem';
@@ -29,9 +30,16 @@ export type CartActions = {
   updateItem: (payload: CartItem) => void;
   removeFromCart: (payload: CartItem) => void;
   incrementItem: (payload: CartItem) => void;
+  initCart: (payload: CartItem[]) => void;
   decrementItem: (payload: CartItem) => void;
   toggleCart: (payload: CartToggleStates) => void;
   clearCart: () => void;
+};
+
+export type InitCartAction = {
+  type: 'cart/init-cart';
+  payload: CartItem[];
+  initCart?: InitCartFunction;
 };
 
 export type AddToCartAction = {
@@ -96,6 +104,7 @@ export type CartReducerAction =
   | AddToCartAction
   | UpdateItemAction
   | IncrementItemAction
+  | InitCartAction
   | DecrementItemAction
   | RemoveFromCartAction
   | ToggleVisibilityAction
@@ -125,6 +134,7 @@ export type { AddToCartFunction } from './actions/addToCart';
 export type { ClearCartFunction } from './actions/clearCart';
 export type { DecrementItemFunction } from './actions/decrementItem';
 export type { IncrementItemFunction } from './actions/incrementItem';
+export type { InitCartFunction } from './actions/initCart';
 export type { RemoveFromCartFunction } from './actions/removeFromCart';
 export type { ToggleCartFunction } from './actions/toggleCart';
 export type { UpdateItemFunction } from './actions/updateItem';

--- a/packages/react-hooks/src/hooks/use-cart/utils/index.ts
+++ b/packages/react-hooks/src/hooks/use-cart/utils/index.ts
@@ -1,3 +1,4 @@
+import { set, del } from 'idb-keyval';
 import { CartItem } from '../../common/types';
 import { LegacyCartItem, StorageTypes } from '../use-cart.types';
 
@@ -20,7 +21,14 @@ export function setCacheItem(storage: StorageTypes | null) {
     return window.sessionStorage.setItem.bind(sessionStorage);
   }
 
-  return () => {};
+  return (cacheKey: string | null, payload: string) => {
+    if (storage === 'idb') {
+      if (cacheKey && payload) {
+        return set(cacheKey, payload);
+      }
+    }
+    return {};
+  };
 }
 
 export function unsetCacheItem(storage: StorageTypes | null) {
@@ -29,8 +37,14 @@ export function unsetCacheItem(storage: StorageTypes | null) {
   } else if (storage === 'session') {
     return window.sessionStorage.removeItem.bind(sessionStorage);
   }
-
-  return () => {};
+  return (cacheKey: string | null) => {
+    if (storage === 'idb') {
+      if (cacheKey) {
+        return del(cacheKey);
+      }
+    }
+    return {};
+  };
 }
 
 export function convertLegacyCartItem(legacyItem: LegacyCartItem): CartItem {

--- a/packages/react-hooks/src/hooks/use-cart/utils/index.ts
+++ b/packages/react-hooks/src/hooks/use-cart/utils/index.ts
@@ -15,36 +15,43 @@ export function isItemInCart(cart: CartItem[], payload: CartItem): boolean {
 }
 
 export function setCacheItem(storage: StorageTypes | null) {
-  if (storage === 'local') {
-    return window.localStorage.setItem.bind(localStorage);
-  } else if (storage === 'session') {
-    return window.sessionStorage.setItem.bind(sessionStorage);
-  }
-
-  return (cacheKey: string | null, payload: string) => {
-    if (storage === 'idb') {
-      if (cacheKey && payload) {
-        return set(cacheKey, payload);
-      }
+  switch (storage) {
+    case 'local': {
+      return window.localStorage.setItem.bind(localStorage);
     }
-    return {};
-  };
+
+    case 'session': {
+      return window.sessionStorage.setItem.bind(sessionStorage);
+    }
+
+    case 'idb': {
+      return (key: string, value: string) => set(key, value);
+    }
+
+    default: {
+      return () => {};
+    }
+  }
 }
 
 export function unsetCacheItem(storage: StorageTypes | null) {
-  if (storage === 'local') {
-    return window.localStorage.removeItem.bind(localStorage);
-  } else if (storage === 'session') {
-    return window.sessionStorage.removeItem.bind(sessionStorage);
-  }
-  return (cacheKey: string | null) => {
-    if (storage === 'idb') {
-      if (cacheKey) {
-        return del(cacheKey);
-      }
+  switch (storage) {
+    case 'local': {
+      return window.localStorage.removeItem.bind(localStorage);
     }
-    return {};
-  };
+
+    case 'session': {
+      return window.sessionStorage.removeItem.bind(sessionStorage);
+    }
+
+    case 'idb': {
+      return (key: string) => del(key);
+    }
+
+    default: {
+      return () => {};
+    }
+  }
 }
 
 export function convertLegacyCartItem(legacyItem: LegacyCartItem): CartItem {

--- a/packages/react-hooks/src/hooks/use-checkout/checkout-requests/getCheckout.ts
+++ b/packages/react-hooks/src/hooks/use-checkout/checkout-requests/getCheckout.ts
@@ -67,6 +67,8 @@ export default async function getCheckout({
 
     throw new Error(error.message);
   } catch (err) {
-    throw new Error(err);
+    if (typeof err === 'string') {
+      throw new Error(err);
+    }
   }
 }

--- a/packages/react-hooks/src/hooks/use-checkout/checkout-requests/processCheckout.ts
+++ b/packages/react-hooks/src/hooks/use-checkout/checkout-requests/processCheckout.ts
@@ -122,6 +122,8 @@ export default async function processCheckout({
   } catch (err) {
     setIsCheckingOut(false);
 
-    throw new Error(err);
+    if (typeof err === 'string') {
+      throw new Error(err);
+    }
   }
 }


### PR DESCRIPTION
**What This PR Does**
- Adds `indexdb` storage options for `useCart` hook per merchant request: https://nacelle.atlassian.net/browse/LD-441
- Updates `CartProvider` to dispatch initial `cartReducer` state inside of `useEffect`
- Adds test for initializing the cart

**How To Test**
- Checkout this branch locally and build `react-hooks`.
- Update the nextjs examples project to set the storage option to `idb` 
```
<CartProvider storage={'idb'}>
```
- Make cart updates, and then hard reload page.

**Notes**
- During initial testing the cart icon count seemed off.  But after further investigation it looks to calculate the total number of unique items in cart, not the total quantity of items in cart
- 2 of variant 123 = 1 item in cart
- 2 of variant 123, 1 of variant 234 = 2 items in cart


