### PR TITLE
[examples/*] Upgrade react, react-dom, and next

### DIFF
--- a/examples/gatsby/package.json
+++ b/examples/gatsby/package.json
@@ -39,8 +39,8 @@
     "gatsby-plugin-sharp": "^2.9.0",
     "gatsby-source-filesystem": "^2.6.1",
     "gatsby-transformer-sharp": "^2.7.0",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.11.1",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -15,9 +15,9 @@
     "@nacelle/react-hooks": "^5.2.0",
     "@react-hook/media-query": "^1.1.1",
     "fuse.js": "^6.4.1",
-    "next": "^10.1.3",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "next": "^11.1.2",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.11.1",

--- a/examples/withKlaviyo/package.json
+++ b/examples/withKlaviyo/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@nacelle/react-components": "^5.0.0",
-    "next": "^10.1.3",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "next": "^11.1.2",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@nacelle/react-klaviyo": "^5.1.2",

--- a/examples/withRecharge/package.json
+++ b/examples/withRecharge/package.json
@@ -14,9 +14,9 @@
     "@nacelle/react-components": "^5.0.0",
     "@nacelle/react-hooks": "^5.2.0",
     "atob": "^2.1.2",
-    "next": "^10.1.3",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "next": "^11.1.2",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@nacelle/react-recharge": "^5.0.0",

--- a/examples/withYotpo/package.json
+++ b/examples/withYotpo/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@nacelle/react-components": "^5.0.0",
-    "next": "^10.1.3",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "next": "^11.1.2",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@nacelle/react-yotpo": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
     "lerna": "^3.22.1",
     "lint-staged": "^10.2.11",
     "listr2": "^3.1.1",
-    "next": "^10.2.0",
+    "next": "^11.1.2",
     "node-emoji": "^1.10.0",
     "prettier": "^2.1.2",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-test-renderer": "^16.13.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.23.1",
@@ -69,6 +69,5 @@
       "pre-commit": "lerna run --concurrency 1 --stream precommit --since HEAD --exclude-dependents",
       "pre-push": "npm run test:ci"
     }
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

**Story:** [LD-69](https://nacelle.atlassian.net/browse/LD-69)

> As a merchant developer, I want the nacelle-react repo to use the latest major version of React, so that the Next.js example sites can take advantage of the latest & greatest Next.js features

### Type of Change

- [x] Chore (docs, refactor, etc)

### What is being changed and why?

<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, gifs, etc are appreciated
-->

In order to take advantage of the latest Next.js features and bug fixes, [the version of `react` and `react-dom` used in the Nextjs `examples/*` needs to be at least `17.0.2`](https://nextjs.org/docs/messages/react-version).

### How to Test

<!--
  If applicable, please provide a way to test the changes in a step-by-step manner
-->

1. `npm run bootstrap` from the monorepo root
2. `cd examples/nextjs && npm run dev`
3. verify that the site at `localhost:4000` works as expected
