### PR TITLE
docs: encourage project scaffolding without cloning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Making Contributions
+
+Nacelle welcomes contributions to our open source projects. We use [Github Issues](https://guides.github.com/features/issues) for bug reports and feature requests, and we accept community pull requests that help move `nacelle-react` forward.
+
+Before making a pull request, please follow our guidelines for local development:
+
+# Local Development
+
+## Prerequisites
+
+- Node >= v14.0.0
+
+## Getting Started
+
+`nacelle-react` is a monorepo managed by [Lerna](https://github.com/lerna/lerna). Start by installing Lerna and all of the sub-projects' dependencies:
+
+```
+npm install && npm run bootstrap
+```
+
+This will install dependencies for all of the packages, and Lerna will hoist any common packages to the root directory to save space. This means that the root of the project will hold all the common package dependencies and create symlinks in the local package `node_modules` folder.
+
+## Workflow
+
+**Note:** It's recommended that you install `lerna` globally for these commands, but `npx lerna` works as well.
+
+### Adding a New Dependency
+
+In general, it's best to use [`lerna add`](https://github.com/lerna/lerna/tree/main/commands/add#readme) to add new packages to a specific repository. This ensures that local packages do not get out of sync. If you accidentally `npm install` a dependency within one of the packages, you may have to subsequently run `npm run bootstrap` in the project root so that Lerna will re-establish any symlinks. This happens because running `npm install` will overwrite any local symmlinks with the version of the package from the NPM repository.
+
+Here are some examples:
+
+```bash
+# adds cool-package as a dependency to every package
+lerna add cool-package
+
+# adds cool-package as a dev-dependency to every package
+lerna add cool-package --dev
+
+# adds cool-package as a dev-dependency to the component-library package only
+lerna add cool-package --dev --scope=component-library
+
+# adds @nacelle/react-hooks (local) to the component library package only (and automatically creates appropriate symlinks)
+lerna add @nacelle/react-hooks --scope=component-library
+```
+
+### Running Commands Across Projects
+
+Lerna can run npm commands across all projects that have the same commands. Running `npm run test` from the root will run `npm run test` in all the `packages/` that have a "test" npm script.
+
+In the root project, the following global commands are available:
+
+- `npm run test`
+- `npm run lint`
+
+### Publishing a Package
+
+```
+npm run publish
+```
+
+This will update and publish all packages that have changed since the last release (it will show you which packages and the versions that will be published). This makes it easy for making changes across interdependent packages. More info [here](https://github.com/lerna/lerna/tree/main/commands/publish#readme).
+
+## Packages
+
+### Creating a New Package
+
+To create a new example project or a new NPM package within the repo, just run `npm run create` from the project root. This script will prompt you and create the appropriate folders with linting, testing, etc already setup!
+
+#### Ensure Public Access for Scoped Packages
+
+If your package is scoped (i.e. `@nacelle/package-name`), be sure to include the `publichConfig` property in the `package.json`. This specifies that the scoped package should be public (the default is private for scoped packages).
+
+```json
+"publishConfig": {
+  "access": "public"
+}
+```
+
+## Example Projects
+
+When creating an example project, be sure to include
+
+```json
+"private": true
+```
+
+in the `package.json` so that Lerna will not publish that package to NPM.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ All `nacelle-react` [**packages**](https://github.com/getnacelle/nacelle-react/t
 
 ## Examples
 
-[**Examples**](https://github.com/getnacelle/nacelle-react/tree/main/examples) demonstrate React project setups with a particular metaframework or third-party integration.
+[**Examples**](https://github.com/getnacelle/nacelle-react/tree/main/examples) demonstrate React project setups with metaframeworks such as [Next.js](https://github.com/getnacelle/nacelle-react/tree/main/examples/nextjs) and [Gatsby](https://github.com/getnacelle/nacelle-react/tree/main/examples/gatsby)) and a variety of third-party integrations.
 
 To scaffold a frontend example project, we recommend using [`degit`](https://www.npmjs.com/package/degit):
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,17 @@ All `nacelle-react` [**packages**](https://github.com/getnacelle/nacelle-react/t
 
 [**Examples**](https://github.com/getnacelle/nacelle-react/tree/main/examples) demonstrate React project setups with metaframeworks such as [Next.js](https://github.com/getnacelle/nacelle-react/tree/main/examples/nextjs) and [Gatsby](https://github.com/getnacelle/nacelle-react/tree/main/examples/gatsby)) and a variety of third-party integrations.
 
-To scaffold a frontend example project, we recommend using [`degit`](https://www.npmjs.com/package/degit):
+Using `degit` for project scaffolding allows you to create a fresh project without needing to clone the `nacelle-react` monorepo. To scaffold a frontend example project, we recommend using [`degit`](https://www.npmjs.com/package/degit):
 
 ```
 npx degit https://github.com/getnacelle/nacelle-react/examples/<example-project-name> my-new-project
 ```
 
-Using `degit` for project scaffolding allows you to create a fresh project without needing to clone the `nacelle-react` monorepo.
+After scaffolding up a new project with `degit`, we recommend initializing source control with Git:
+
+```
+git init -b main
+```
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -1,101 +1,25 @@
-# Nacelle React
+# `nacelle-react`
 
-This is a monorepo managed by [Lerna](https://github.com/lerna/lerna). Projects in the monorepo can be found in `./packages`.
+Nacelle is a managed backend service that acts as the connective tissue for headless commerce. Our infrastructure is built on an event-driven elastic core that Nacelle fully manages, so you don't have to worry about scaling, updates, and general DevOps. We focus on fighting headless headaches like eventual consistency, backend maintenance, and interoperability so you can build the things that matter to your brand without getting bogged down.
 
-## Prerequisites
-
-- Node >= v14.0.0 (LTS)
-
-## Getting Started
-
-```
-npm install && npm run bootstrap
-```
-
-This will install dependencies for all of the packages, and Lerna will hoist any common packages to the root directory to save space. This means that the root of the project will hold all the common package dependencies and create symlinks in the local package `node_modules` folder.
-
-## Workflow
-
-**Note:** It's recommended that you install `lerna` globally for these commands, but `npx lerna` works as well.
-
-### Adding a New Dependency
-
-In general, it's best to use [`lerna add`](https://github.com/lerna/lerna/tree/main/commands/add#readme) to add new packages to a specific repository. This ensures that local packages do not get out of sync. If you accidentally `npm install` a dependency within one of the packages, you may have to subsequently run `npm run bootstrap` in the project root so that Lerna will re-establish any symlinks. This happens because running `npm install` will overwrite any local symmlinks with the version of the package from the NPM repository.
-
-Here are some examples:
-
-```bash
-# adds cool-package as a dependency to every package
-lerna add cool-package
-
-# adds cool-package as a dev-dependency to every package
-lerna add cool-package --dev
-
-# adds cool-package as a dev-dependency to the component-library package only
-lerna add cool-package --dev --scope=component-library
-
-# adds @nacelle/react-hooks (local) to the component library package only (and automatically creates appropriate symlinks)
-lerna add @nacelle/react-hooks --scope=component-library
-```
-
-### Running Commands Across Projects
-
-Lerna can run npm commands across all projects that have the same commands. Running `npm run test` from the root will run `npm run test` in all the `packages/` that have a "test" npm script.
-
-In the root project, the following global commands are available:
-
-- `npm run test`
-- `npm run lint`
-
-### Publishing a Package
-
-```
-npm run publish
-```
-
-This will update and publish all packages that have changed since the last release (it will show you which packages and the versions that will be published). This makes it easy for making changes across interdependent packages. More info [here](https://github.com/lerna/lerna/tree/main/commands/publish#readme).
+This repository contains packages and examples you can use to build your Nacelle-powered storefront with React.js.
 
 ## Packages
 
-- [`react-hooks`](https://github.com/getnacelle/nacelle-react/tree/main/packages/react-hooks): Convenience hooks for use in React applications with Nacelle
-- [`component-library`](https://github.com/getnacelle/nacelle-react/tree/main/packages/component-library): Atomic UI components that can be used to create React applications with Nacelle
-- [`gatsby-source-nacelle`](https://github.com/getnacelle/nacelle-react/tree/main/packages/gatsby-source-nacelle): A Gatsby source plugin that integrates with the Nacelle SDK
-- [`react-klaviyo`](https://github.com/getnacelle/nacelle-react/tree/main/packages/react-klaviyo): Klaviyo components for integrating with Shopify
-- [`react-recharge`](https://github.com/getnacelle/nacelle-react/tree/main/packages/react-recharge): Recharge components for integrating with Shopify
-- [`react-yotpo`](https://github.com/getnacelle/nacelle-react/tree/main/packages/react-yotpo): Yotpo components for integrating with Shopify
+All `nacelle-react` [**packages**](https://github.com/getnacelle/nacelle-react/tree/main/packages) are published to npm. Please refer to a package's README for installation instructions.
 
-### Creating a New Package
+## Examples
 
-To create a new example project or a new NPM package within the repo, just run `npm run create` from the project root. This script will prompt you and create the appropriate folders with linting, testing, etc already setup!
+[**Examples**](https://github.com/getnacelle/nacelle-react/tree/main/examples) demonstrate React project setups with a particular metaframework or third-party integration.
 
-#### Ensure Public Access for Scoped Packages
+To scaffold a frontend example project, we recommend using [`degit`](https://www.npmjs.com/package/degit):
 
-If your package is scoped (i.e. `@nacelle/package-name`), be sure to include the `publichConfig` property in the `package.json`. This specifies that the scoped package should be public (the default is private for scoped packages).
-
-```json
-"publishConfig": {
-  "access": "public"
-}
+```
+npx degit https://github.com/getnacelle/nacelle-react/examples/<example-project-name> my-new-project
 ```
 
-## Example Projects
+Using `degit` for project scaffolding allows you to create a fresh project without needing to clone the `nacelle-react` monorepo.
 
-- [`gatsby`](https://github.com/getnacelle/nacelle-react/tree/main/examples/gatsby): A simple Gatsby implementation that uses `gatsby-source-nacelle`
-- [`nextjs`](https://github.com/getnacelle/nacelle-react/tree/main/examples/nextjs): An e-commerce store exmaple that uses the Nacelle `component-library` and `react-hooks`
-- [`withKlaviyo`](https://github.com/getnacelle/nacelle-react/tree/main/examples/withKlaviyo): An example of integrating Klaviyo with Next.js using `react-klaviyo`
-- [`withRecharge`](https://github.com/getnacelle/nacelle-react/tree/main/examples/withRecharge): An example of integrating ReCharge with Next.js using `react-recharge`
-- [`withYotpo`](https://github.com/getnacelle/nacelle-react/tree/main/examples/withYotpo): An example of integrating Yotpo with Next.js using `react-yotpo`
+## How to Contribute
 
-### Creating a New Example
-
-Coming soon: a scripted way to create a new package in this project.
-
-#### Ensure Examples Are Private
-
-When creating an example project, be sure to include
-
-```json
-"private": true
-```
-
-in the `package.json` so that Lerna will not publish that package to NPM.
+Please see our [Contribution Guidelines](./CONTRIBUTING.md) for more information about contributing to `nacelle-react`.


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

**Story:** [LS-1305](https://nacelle.atlassian.net/browse/LS-1305)


> Rewrite Nacelle React Readme to be explicit on how to interact with it as a merchant developer vs a repo contributor

### Type of Change

Chore (docs, refactor, etc)

### What is being changed and why?

The README was giving merchant developers the impression that they should clone the entire `nacelle-react` monorepo in order to work with `examples/*` projects. This caused headaches when scaffolding a new project with `examples/gatsby` / `examples/nextjs`.

This PR:

1. Moves monorepo-specific / local development guidelines to `CONTRIBUTING.md`.
2. Gives explicit instructions in `README.md` for scaffolding new projects from `examples/*` projects, without the need to clone and bootstrap the `nacelle-react` monorepo.

### How to Test

<!--
  If applicable, please provide a way to test the changes in a step-by-step manner
-->

Check out [`README.md`](https://github.com/getnacelle/nacelle-react/tree/LS-1305-rewrite-readme-for-clarity#readme) and [`CONTRIBUTING.md`](https://github.com/getnacelle/nacelle-react/blob/LS-1305-rewrite-readme-for-clarity/CONTRIBUTING.md).

Feel free to follow the project scaffolding instructions with `degit` as described in `README.md`.
