### PR TITLE
feat(gatsby): add option to pass Nacelle client to gatsby plugin

### DIFF
--- a/examples/gatsby/gatsby-config.js
+++ b/examples/gatsby/gatsby-config.js
@@ -1,13 +1,20 @@
 require('dotenv').config();
 
+const NacelleClient = require('@nacelle/client-js-sdk').default;
+
+const client = new NacelleClient({
+  useStatic: false,
+  token: process.env.GATSBY_NACELLE_GRAPHQL_TOKEN,
+  id: process.env.GATSBY_NACELLE_SPACE_ID,
+  nacelleEndpoint: process.env.GATSBY_NACELLE_ENDPOINT
+});
+
 module.exports = {
   plugins: [
     {
       resolve: '@nacelle/gatsby-source-nacelle',
       options: {
-        nacelleSpaceId: process.env.GATSBY_NACELLE_SPACE_ID,
-        nacelleGraphqlToken: process.env.GATSBY_NACELLE_GRAPHQL_TOKEN,
-        nacelleEndpoint: process.env.GATSBY_NACELLE_ENDPOINT,
+        nacelleClient: client,
         cacheDuration: 1000 * 60 * 60 * 24 // 1 day in ms
       }
     },

--- a/packages/gatsby-source-nacelle/README.md
+++ b/packages/gatsby-source-nacelle/README.md
@@ -33,34 +33,34 @@ npm i @nacelle/gatsby-source-nacelle
 
 ### Configure
 
-Then add the plugin to your `gatsby-config.js`. Be sure to include your `nacelle-space-id` and `nacelle-graphql-token`, which you can find in your Space settings in the [Nacelle Dashboard](https://dashboard.getnacelle.com/).
-
-#### Adding Your Credentials Securely
-
-Create a `.env` file with your Nacelle credentials. For more information about using environment variables in a Gatsby project, check out the [Gatsby docs](https://www.gatsbyjs.org/docs/environment-variables/).
-
-```dotenv
-# .env
-NACELLE_SPACE_ID=your-nacelle-space-id
-NACELLE_GRAPHQL_TOKEN=your-nacelle-graphql-token
-```
+It's recommended to create a NacelleClient and pass it to `gatsby-source-nacelle`. This gives you the best control of your client, allowing you to setup [CMS previews](https://docs.getnacelle.com/integrations/contentful-preview.html) and the [Nacelle V2 Compatibility Connector](https://www.npmjs.com/package/@nacelle/compatibility-connector).
 
 ```javascript
 // gatsby-config.js
 require('dotenv').config();
+
+const NacelleClient = require('@nacelle/client-js-sdk').default;
+
+const client = new NacelleClient({
+  useStatic: false,
+  token: process.env.GATSBY_NACELLE_GRAPHQL_TOKEN,
+  id: process.env.GATSBY_NACELLE_SPACE_ID,
+  nacelleEndpoint: process.env.GATSBY_NACELLE_ENDPOINT
+});
 
 module.exports = {
   plugins: [
     {
       resolve: '@nacelle/gatsby-source-nacelle',
       options: {
-        nacelleSpaceId: process.env.NACELLE_SPACE_ID,
-        nacelleGraphqlToken: process.env.NACELLE_GRAPHQL_TOKEN
+        nacelleClient: client
       }
     }
   ]
 };
 ```
+
+You'll note that we use `.env` variables to set Nacelle credentials. You can learn more about using environment variables with Gatsby in the [Gatsby docs](https://www.gatsbyjs.org/docs/environment-variables/)
 
 ## Additional Features
 

--- a/packages/gatsby-source-nacelle/README.md
+++ b/packages/gatsby-source-nacelle/README.md
@@ -33,7 +33,7 @@ npm i @nacelle/gatsby-source-nacelle
 
 ### Configure
 
-It's recommended to create a NacelleClient and pass it to `gatsby-source-nacelle`. This gives you the best control of your client, allowing you to setup [CMS previews](https://docs.getnacelle.com/integrations/contentful-preview.html) and the [Nacelle V2 Compatibility Connector](https://www.npmjs.com/package/@nacelle/compatibility-connector).
+It's recommended to create a NacelleClient and pass it to `gatsby-source-nacelle`. This gives you the best control of your client, allowing you to setup [CMS previews](https://docs.getnacelle.com/integrations/contentful-preview.html) and the [Nacelle v2 Compatibility Connector](https://www.npmjs.com/package/@nacelle/compatibility-connector).
 
 ```javascript
 // gatsby-config.js

--- a/packages/gatsby-source-nacelle/gatsby-node.js
+++ b/packages/gatsby-source-nacelle/gatsby-node.js
@@ -11,7 +11,9 @@ exports.pluginOptionsSchema = ({ Joi }) => {
     nacelleGraphqlToken: Joi.string().description(
       'GraphQL Token from the Nacelle Dashboard'
     ),
-    nacelleClient: Joi.optional(),
+    nacelleClient: Joi.optional().description(
+      'Instance of the `@nacelle/client-js-sdk` which you want to use to fetch your nacelle data'
+    ),
     contentfulPreviewApiToken: Joi.string().description(
       'Contentful Preview API token from Contentful Dashboard settings'
     ),

--- a/packages/gatsby-source-nacelle/gatsby-node.js
+++ b/packages/gatsby-source-nacelle/gatsby-node.js
@@ -11,8 +11,14 @@ exports.pluginOptionsSchema = ({ Joi }) => {
     nacelleGraphqlToken: Joi.string().description(
       'GraphQL Token from the Nacelle Dashboard'
     ),
+    nacelleEndpoint: Joi.string().description(
+      'Storefront Endpoint from the Nacelle Dashboard'
+    ),
     nacelleClient: Joi.optional().description(
       'Instance of the `@nacelle/client-js-sdk` which you want to use to fetch your nacelle data'
+    ),
+    contentfulPreviewSpaceId: Joi.string().description(
+      'Space ID from Contentful Dashboard settings'
     ),
     contentfulPreviewApiToken: Joi.string().description(
       'Contentful Preview API token from Contentful Dashboard settings'
@@ -36,16 +42,16 @@ exports.sourceNodes = async (gatsbyApi, pluginOptions) => {
     nacelleClient
   } = pluginOptions;
 
-  const client = nacelleClient
-    ? nacelleClient
-    : createNacelleClient({
-        previewMode: cmsPreviewEnabled(pluginOptions),
-        nacelleSpaceId,
-        nacelleGraphqlToken,
-        nacelleEndpoint,
-        contentfulPreviewSpaceId,
-        contentfulPreviewApiToken
-      });
+  const client =
+    nacelleClient ||
+    createNacelleClient({
+      previewMode: cmsPreviewEnabled(pluginOptions),
+      nacelleSpaceId,
+      nacelleGraphqlToken,
+      nacelleEndpoint,
+      contentfulPreviewSpaceId,
+      contentfulPreviewApiToken
+    });
 
   const [
     spaceData,

--- a/packages/gatsby-source-nacelle/gatsby-node.js
+++ b/packages/gatsby-source-nacelle/gatsby-node.js
@@ -2,7 +2,6 @@ const sourceNodes = require('./src/source-nodes');
 const typeDefs = require('./src/type-defs');
 const { createRemoteImageFileNode, cmsPreviewEnabled } = require('./src/utils');
 const { nacelleClient: createNacelleClient } = require('./src/services');
-// const NacelleClient = require('@nacelle/client-js-sdk').default;
 
 exports.pluginOptionsSchema = ({ Joi }) => {
   return Joi.object({


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

**Story:** [LS-1414](https://nacelle.atlassian.net/browse/LS-1414) <!-- link to Jira story -->

## Type of Change

- [ ] Bug fix
- [x] Non-breaking feature
- [ ] Breaking feature
- [ ] Chore (docs, refactor, etc)

## What is being changed and why?

1. Adds a nacelleClient option to the gatsby plugin that allows users to pass in their own client.
2. Updates the gatsby example to use this option
<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, gifs, etc are appreciated
-->

## How to Test

1. Pull `LS-1414-allow-users-to-pass-in-client-sdk`
2. Test a build with `npm run build` in the root of the repo
3. Build the gatsby example by navigating to `examples/gatsby` and running `npm run build`
   1. You may need to get the `.env` variables from Vercel
<!--
  If applicable, please provide a way to test the changes in a step-by-step manner
-->
