### PR TITLE
(fix): race condition in processCheckout

### DIFF
--- a/examples/gatsby/src/components/Cart/Cart.js
+++ b/examples/gatsby/src/components/Cart/Cart.js
@@ -11,17 +11,28 @@ import * as styles from './Cart.styles';
 const Cart = () => {
   const [{ cart, show }, cartActions] = useCart();
   const { isMobile } = useDetectDevice();
-  const [checkoutData, checkoutActions, isCheckingOut] = useCheckout();
+  const [checkoutData, checkoutActions] = useCheckout();
+  const [isCheckingOut, setIsCheckingOut] = useState(false);
   const checkoutItems = cart.map((cartItem) => ({
     quantity: cartItem.quantity,
     variantId: cartItem.variant.id,
     metafields: [...cartItem.product.metafields, ...cartItem.variant.metafields]
   }));
+
   const processCheckout = async () => {
-    await checkoutActions
+    // initiate checkout & redirect customer to checkout URL
+    setIsCheckingOut(true);
+
+    return await checkoutActions
       .processCheckout({ cartItems: checkoutItems })
-      .then(() => {
-        window.location = checkoutData.url;
+      .then(({ url, completed }) => {
+        if (url && !completed) {
+          window.location.href = url;
+        }
+      })
+      .catch((err) => {
+        setIsCheckingOut(false);
+        console.error(err);
       });
   };
 

--- a/examples/nextjs/pages/_app.js
+++ b/examples/nextjs/pages/_app.js
@@ -1,8 +1,7 @@
 import App from 'next/app';
 import React from 'react';
 import { Global } from '@emotion/core';
-import { CartProvider } from '@nacelle/react-hooks';
-import { CheckoutProvider } from '@nacelle/react-hooks';
+import { CartProvider, CheckoutProvider } from '@nacelle/react-hooks';
 import createShopifyCheckoutClient from '@nacelle/shopify-checkout';
 
 import Layout from 'components/Layout';

--- a/packages/react-hooks/src/hooks/use-checkout/use-checkout.provider.tsx
+++ b/packages/react-hooks/src/hooks/use-checkout/use-checkout.provider.tsx
@@ -35,15 +35,18 @@ const CheckoutClientContext = React.createContext<CheckoutClient>({
   process: () => Promise.resolve({ id: '', url: '', completed: false })
 });
 
-const CheckoutDataContext =
-  React.createContext<CheckoutContextValue>(initialState);
-const CheckoutActionContext =
-  React.createContext<CheckoutActionContextValue>(null);
+const CheckoutDataContext = React.createContext<CheckoutContextValue>(
+  initialState
+);
+const CheckoutActionContext = React.createContext<CheckoutActionContextValue>(
+  null
+);
 const IsCheckingOutContext = React.createContext<boolean>(false);
 
 export const CheckoutProvider: FC<CheckoutProviderProps> = ({
   children,
-  checkoutClient
+  checkoutClient,
+  redirectUserToCheckout
 }) => {
   const [isCheckingOut, setIsCheckingOut] = useState(false);
   const isMounted = useRef(true);
@@ -131,6 +134,15 @@ export const CheckoutProvider: FC<CheckoutProviderProps> = ({
       getCheckout({ id, url }).catch((err) => console.warn(err));
     }
   }, [checkoutState, getCheckout, isCheckingOut]);
+
+  useEffect(() => {
+    if (typeof redirectUserToCheckout !== 'undefined') {
+      console.warn(
+        '[@nacelle/react-hooks|useCheckout] The `redirectUserToCheckout` prop is deprecated. ' +
+          'Please handle the customer redirect to the checkout URL in your project code.'
+      );
+    }
+  });
 
   return (
     <CheckoutClientContext.Provider value={checkoutClient}>

--- a/packages/react-hooks/src/hooks/use-checkout/use-checkout.types.ts
+++ b/packages/react-hooks/src/hooks/use-checkout/use-checkout.types.ts
@@ -76,7 +76,7 @@ export interface CheckoutClient {
 export type CheckoutProviderProps = {
   children: JSX.Element | JSX.Element[];
   checkoutClient: CheckoutClient;
-  redirectUserToCheckout: boolean;
+  redirectUserToCheckout?: boolean;
 };
 
 export type CheckoutContextValue = null | CheckoutState;


### PR DESCRIPTION
### Story

[LS-1458](https://nacelle.atlassian.net/browse/LS-1458)

> Race condition in processCheckout in nacelle-react/examples/{nextjs|gatsby}

### Type of Change

Bug fix (will bump to `6.1.1`).

### What is being changed and why?

#### `examples/gatsby` and `examples/nextjs`

The `<Cart />` component's `processCheckout` handler was encountering a race condition (described in the ticket). We can avoid the race condition by leveraging the value of the resolved `checkoutActions.processCheckout` Promise, which contains the checkout `url` that the customer gets redirected to.

#### `packages/react-hooks`

As of [`@nacelle/react-hooks@6.0.0`](https://nacelle.atlassian.net/wiki/spaces/PI/pages/1252819054/nacelle+react-hooks#Redirecting-customers-to-checkout), the `redirectUserToCheckout` prop does nothing. This PR adds a deprecaction warning in the console and advises the merchant developer to handle the customer's redirect to checkout in their project code.

### How to Test

1. Visit https://nacelle-nextjs-example-git-ls-1458-race-conditio-cfe9d4-nacelle.vercel.app, add some items to cart, and checkout.

https://user-images.githubusercontent.com/5732000/150184695-8e859415-ba70-4bcd-9b15-0c8c4fbe272c.mov

2. Check out the `LS-1458-race-condition-in-processcheckout` branch.
3. `npm run bootstrap` from the monorepo root.
4. `cd packages/react-hooks`
5. `npm run build` (should build without errors).
6. `npm run test` (all tests should pass). 

If testing in `examples/nextjs` or `examples/gatsby`, setting the `redirectUserToCheckout` prop on `<CheckoutProvider />` will result in a console warning:

<img width="400" alt="LS-1458-race-condition-in-processcheckout deprecation warning for redirectUserToCheckout prop" src="https://user-images.githubusercontent.com/5732000/150212825-98239aa2-97b9-4453-b303-41ea8811fd42.png">
 