### PR TITLE
chore: add deprecation messages to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # `nacelle-react`
 
-This monorepo and all `packages/`, `examples/`, etc. contained therewithin are deprecated. For up-to-date information about building frontend projects powered by Nacelle, please see [`docs.nacelle.com`](https://docs.nacelle.com/docs/heads).
+This monorepo and all `packages/`, `examples/`, etc. contained therewithin are deprecated. For up-to-date information and examples related to building frontend projects powered by Nacelle, please see [`docs.nacelle.com`](https://docs.nacelle.com/docs/heads) and the [`nacelle-js`](https://github.com/getnacelle/nacelle-js) repo.

--- a/README.md
+++ b/README.md
@@ -1,29 +1,3 @@
 # `nacelle-react`
 
-Nacelle is a managed backend service that acts as the connective tissue for headless commerce. Our infrastructure is built on an event-driven elastic core that Nacelle fully manages, so you don't have to worry about scaling, updates, and general DevOps. We focus on fighting headless headaches like eventual consistency, backend maintenance, and interoperability so you can build the things that matter to your brand without getting bogged down.
-
-This repository contains packages and examples you can use to build your Nacelle-powered storefront with React.js.
-
-## Packages
-
-All `nacelle-react` [**packages**](https://github.com/getnacelle/nacelle-react/tree/main/packages) are published to npm. Please refer to a package's README for installation instructions.
-
-## Examples
-
-[**Examples**](https://github.com/getnacelle/nacelle-react/tree/main/examples) demonstrate React project setups with metaframeworks such as [Next.js](https://github.com/getnacelle/nacelle-react/tree/main/examples/nextjs) and [Gatsby](https://github.com/getnacelle/nacelle-react/tree/main/examples/gatsby)) and a variety of third-party integrations.
-
-Using `degit` for project scaffolding allows you to create a fresh project without needing to clone the `nacelle-react` monorepo. To scaffold a frontend example project, we recommend using [`degit`](https://www.npmjs.com/package/degit):
-
-```
-npx degit https://github.com/getnacelle/nacelle-react/examples/<example-project-name> my-new-project
-```
-
-After scaffolding up a new project with `degit`, we recommend initializing source control with Git:
-
-```
-git init -b main
-```
-
-## How to Contribute
-
-Please see our [Contribution Guidelines](./CONTRIBUTING.md) for more information about contributing to `nacelle-react`.
+This monorepo and all `packages/`, `examples/`, etc. contained therewithin are deprecated. For up-to-date information about building frontend projects powered by Nacelle, please see [`docs.nacelle.com`](https://docs.nacelle.com/docs/heads).

--- a/packages/component-library/README.md
+++ b/packages/component-library/README.md
@@ -2,6 +2,10 @@
 
 > React Components for building Nacelle apps
 
+## NOTICE
+
+This package is deprecated. For up-to-date information and examples related to building frontend projects powered by Nacelle, please see [`docs.nacelle.com`](https://docs.nacelle.com/docs/heads) and the [`nacelle-js`](https://github.com/getnacelle/nacelle-js) repo.
+
 ## Install
 
 ### With NPM

--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -2,6 +2,10 @@
 
 > React utility functions & TypeScript types for creating Nacelle projects
 
+## NOTICE
+
+This package is deprecated. For up-to-date information and examples related to building frontend projects powered by Nacelle, please see [`docs.nacelle.com`](https://docs.nacelle.com/docs/heads) and the [`nacelle-js`](https://github.com/getnacelle/nacelle-js) repo.
+
 ## Install
 
 ### With NPM

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -2,6 +2,10 @@
 
 > React Hooks for Nacelle-fueled storefronts
 
+## NOTICE
+
+This package is deprecated. For up-to-date information and examples related to building frontend projects powered by Nacelle, please see [`docs.nacelle.com`](https://docs.nacelle.com/docs/heads) and the [`nacelle-js`](https://github.com/getnacelle/nacelle-js) repo.
+
 ## Install
 
 ```bash
@@ -39,9 +43,7 @@ const App = () => {
 You're welcome to create your own checkout client. It just needs to expose two methods:
 
 ```ts
-function get(
-  params: any
-): Promise<{
+function get(params: any): Promise<{
   id: string;
   url: string;
   completed: boolean;
@@ -53,9 +55,7 @@ function get(
   }
 }
 
-function process(
-  params: any
-): Promise<{
+function process(params: any): Promise<{
   id: string;
   url: string;
   completed: boolean;

--- a/packages/react-recharge/README.md
+++ b/packages/react-recharge/README.md
@@ -4,6 +4,10 @@ Adds a React component [Recharge](https://rechargepayments.com/) subscriptions i
 
 ![Image of RechargeSelect Component](component.png)
 
+## NOTICE
+
+This package is deprecated. For up-to-date information and examples related to building frontend projects powered by Nacelle, please see [`docs.nacelle.com`](https://docs.nacelle.com/docs/heads) and the [`nacelle-js`](https://github.com/getnacelle/nacelle-js) repo.
+
 ## Requirements
 
 - A Nacelle project set up locally. See https://docs.getnacelle.com for getting started.

--- a/packages/react-yotpo/README.md
+++ b/packages/react-yotpo/README.md
@@ -4,6 +4,10 @@ Adds React components for [Yotpo](https://www.yotpo.com/) product reviews in you
 
 ![Image of YotpoReviews Component](component.png)
 
+## NOTICE
+
+This package is deprecated. For up-to-date information and examples related to building frontend projects powered by Nacelle, please see [`docs.nacelle.com`](https://docs.nacelle.com/docs/heads) and the [`nacelle-js`](https://github.com/getnacelle/nacelle-js) repo.
+
 ## Requirements
 
 - A Nacelle project set up locally. See https://docs.getnacelle.com for getting started.


### PR DESCRIPTION
## Story

[ENG-9953](https://nacelle.atlassian.net/browse/ENG-9953)

## What is being changed and why?

This PR adds a deprecation message to steer people away from `nacelle-react` and the deprecated projects it contains.

This complements the actual [npm deprecation](https://docs.npmjs.com/cli/v8/commands/npm-deprecate) of these packages.

[ENG-9953]: https://nacelle.atlassian.net/browse/ENG-9953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
